### PR TITLE
feat(settlement): add balances and fewest-transfers settle-up

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -210,9 +210,45 @@ Most tests below use this group:
 
 ---
 
-## 7. Routing
+## 7. Settle up (balances & fewest transfers)
 
-### TC-7.1 — Unknown route shows 404
+Settlement is derived (not stored). Balances use
+`balance = prepaid + paidBy − paidFor`; the **banker** holds the prepaid pot, so
+the net balances (shown on the page) sum to zero and match the transfers. The
+pure logic is also covered by unit tests: `npm test --workspace frontend`.
+
+### TC-7.1 — Choose the banker
+
+1. Open a group → **Config** → set the **Banker** dropdown to a member → **Save**.
+2. **Expected:** the choice persists across reload (defaults to the first member
+   when never set).
+
+### TC-7.2 — Balances and transfers (worked example)
+
+1. Use the `Beach Trip` group (Alice 100 / Bob 0 / Carol 50, banker Alice) with
+   the `Dinner` $120 expense (paid by Carol; split 40/40/40). Open **Settle up**.
+2. **Expected balances (net):** Alice owes $90, Bob owes $40, Carol gets back $130.
+3. **Expected transfers:** `Bob → Carol $40` and `Alice → Carol $90` (2 transfers);
+   the net balances sum to zero.
+
+### TC-7.3 — Prepaid-only refund via the banker
+
+1. Same members, banker Alice, but **no transactions**. Open **Settle up**.
+2. **Expected:** Carol gets back $50, Bob settled, Alice (banker) owes $50;
+   transfer `Alice → Carol $50` (Alice returns Carol's prepaid from the pot and
+   keeps her own).
+
+### TC-7.4 — Everyone already even
+
+1. A group where each member's contributions equal their consumption.
+2. **Expected:** all rows show "settled" and the Transfers panel shows
+   "Everyone is settled up — no transfers needed".
+
+---
+
+## 8. Routing
+
+### TC-8.1 — Unknown route shows 404
 
 1. Navigate to a nonsense path, e.g. `/group/abc/does-not-exist`.
 2. **Expected:** the 404 page ("404 / Content not found") with a link back home.
@@ -224,9 +260,10 @@ Most tests below use this group:
 - **Silent validation on transaction save (TC-3.6):** if Date, Total, or
   Description is empty the Save is ignored without any visible message
   (`Transaction.tsx` logs to console only — there is a `TODO` for UI feedback).
-- **Settlement not implemented:** DivSplit captures `paidBy` / `paidFor` and
-  prepaid balances but does **not** yet compute per-person balances or the
-  minimum set of transfers. There is nothing to test there yet.
+- **Settlement banker model:** settle-up assumes one **banker** holds the prepaid
+  pot and disburses refunds (so a banker can show as "owes" while having prepaid
+  the most — that's the cash they pay out of the pot, and it matches the transfer
+  lines). Transfer minimization is greedy (near-optimal), not provably minimal.
 - **No favicon:** the initial page load logs one harmless `404` for the favicon.
 - **Native date input:** automated tools may need to set the date field
   programmatically; manual testing with the date picker works normally.

--- a/docs/superpowers/specs/2026-06-14-settlement-engine-design.md
+++ b/docs/superpowers/specs/2026-06-14-settlement-engine-design.md
@@ -1,0 +1,115 @@
+# Settlement engine — design
+
+> Status: approved (2026-06-14). Computes per-member balances and the fewest
+> transfers needed to settle a group, accounting for prepaid amounts.
+
+## Goal
+
+Turn a group's transactions and prepaid balances into:
+
+1. a per-member **balance** (owed back / owes / settled), and
+2. the **fewest transfers** that settle everyone, so a 10-person trip never ends
+   with one person sending money to nine others.
+
+This is the headline feature DivSplit promised but never implemented.
+
+## Balance model
+
+For each member `m`:
+
+```
+balance(m) = prepaid(m) + paidBy(m) − paidFor(m)
+```
+
+- `prepaid(m)` — money the member pre-funded (from `config`/member record).
+- `paidBy(m)` — Σ of the member's amounts across all transactions' `paidBy`.
+- `paidFor(m)` — Σ of the member's amounts across all transactions' `paidFor`.
+
+A positive balance means the group owes the member; negative means they owe.
+
+### The banker (prepaid pot)
+
+Per-transaction, `paidBy` total = `paidFor` total, so those net to zero across
+members. Prepaid, however, is extra cash that may not be fully consumed, so raw
+balances sum to `Σ prepaid` (a surplus), not zero — a pure peer-to-peer
+settlement is then impossible.
+
+Resolution: one member is the **banker**, who physically holds the prepaid pot
+(`pot = Σ prepaid`). Their effective balance is reduced by the pot:
+
+```
+effectiveBalance(banker) = balance(banker) − pot
+effectiveBalance(other)  = balance(other)
+```
+
+Now `Σ effectiveBalance = Σ balance − pot = pot − pot = 0`, so the transfers
+fully settle. The banker is stored as `config.bankerId` and defaults to the
+first member when unset; it is selectable on the Config page.
+
+### Worked example
+
+Members: Alice (prepaid 100), Bob (0), Carol (50). One $120 dinner —
+paidBy: Carol 120; paidFor: Alice/Bob/Carol 40 each. Banker = Alice.
+
+```
+balance:    Alice +60, Bob −40, Carol +130     (sum +150 = pot)
+effective:  Alice −90, Bob −40, Carol +130     (sum 0)
+transfers:  Bob → Carol $40, Alice → Carol $90  (2 transfers)
+→ Bob out 40 (=share), Carol net-in 40 (=share), Alice keeps 60 refund ✓
+```
+
+## Components
+
+### 1. `src/utils/settlement.ts` (pure, no UI)
+
+- `computeBalances(group: Group): MemberBalance[]`
+  — `{ memberId, name, balance }` per member.
+- `computeSettlement(group: Group): SettlementResult`
+  — `{ balances: MemberBalance[], transfers: Transfer[], bankerId: string }`.
+  - Determine banker: `group.config.bankerId` or first member.
+  - Apply the banker pot adjustment to effective balances.
+  - **Greedy min-cash-flow:** repeatedly take the largest creditor and largest
+    debtor, transfer `min(|debtor|, creditor)`, reduce both, drop any that reach
+    ~0; emit a `Transfer { fromId, toId, amount }` each step.
+  - Money rounded to cents; balances within a `< 0.005` tolerance are treated as
+    settled (no phantom 1¢ transfers).
+
+Types: `MemberBalance`, `Transfer`, `SettlementResult` added to `types.ts` or
+co-located in `settlement.ts`.
+
+### 2. Banker selection (Config page)
+
+- Add optional `bankerId?: string` to `GroupConfig` in `types.ts`.
+- `Config.tsx`: a member dropdown ("Banker") writing `config.bankerId` on save.
+  Defaults to the first member when unset.
+
+### 3. "Settle up" tab + page
+
+- Add a `settlement` section: 4th tab in `GroupHeader` (Config / Transactions /
+  **Settle up** / Activity), routed via the existing `:section` param in
+  `GroupPageWrapper`.
+- `pages/Group/Settlement.tsx` (read-only):
+  - **Balances**: each member with amount in mono and an owed/owes/settled badge.
+  - **Transfers**: rows reading "**{from}** pays **{to}** `${amount}`". Empty
+    state when everyone is settled.
+
+## Testing
+
+The repo has no test runner yet. Add **Vitest** (+ `npm test` script) and write
+unit tests for `settlement.ts` first (TDD):
+
+- the worked example above (balances + transfers),
+- already-even group (no transfers),
+- single payer / single ower,
+- rounding residuals (amounts like 1/3 splits),
+- empty group / no transactions / banker unset (defaults to first member),
+- a 10-member case asserting transfer count ≤ N−1.
+
+UI components are not unit-tested (covered by the existing manual TEST.md flow,
+which will get a new "Settle up" section).
+
+## Out of scope (future)
+
+Multi-currency, persisted settlement history, "mark transfer as paid", and
+optimal (vs. greedy) transfer minimization. Greedy min-cash-flow is near-optimal
+and matches the product goal.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
 		"build": "tsc -b && vite build",
 		"lint": "eslint . --fix",
 		"preview": "vite preview",
-		"typecheck": "tsc -b"
+		"typecheck": "tsc -b",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@fontsource-variable/fraunces": "^5.2.9",
@@ -42,6 +43,7 @@
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.61.0",
-		"vite": "^8.0.16"
+		"vite": "^8.0.16",
+		"vitest": "^4.1.8"
 	}
 }

--- a/frontend/src/components/GroupHeader.tsx
+++ b/frontend/src/components/GroupHeader.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
-import { Settings2, Receipt, History } from 'lucide-react';
+import { Settings2, Receipt, History, ArrowLeftRight } from 'lucide-react';
 
 import { useGroupContext } from '../context/GroupContext';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,7 @@ export function GroupHeader() {
 	const tabs = [
 		{ key: 'config', label: t('Config'), icon: Settings2 },
 		{ key: 'transactions', label: t('Transactions'), icon: Receipt },
+		{ key: 'settlement', label: t('Settle up'), icon: ArrowLeftRight },
 		{ key: 'activity', label: t('Activity'), icon: History },
 	];
 

--- a/frontend/src/components/GroupPageWrapper.tsx
+++ b/frontend/src/components/GroupPageWrapper.tsx
@@ -10,6 +10,7 @@ import { Debug } from './Debug';
 import { GroupListTransactions } from '../pages/Group/ListTransactions';
 import { GroupTransaction } from '../pages/Group/Transaction';
 import { GroupActivity } from '../pages/Group/Activity';
+import { GroupSettlement } from '../pages/Group/Settlement';
 import { Button } from '@/components/ui/button';
 
 function GroupContent() {
@@ -20,6 +21,7 @@ function GroupContent() {
 	const pages: Record<string, boolean> = {
 		config: section === 'config',
 		transactions: section === 'transactions',
+		settlement: section === 'settlement',
 		activity: section === 'activity',
 	};
 
@@ -37,6 +39,7 @@ function GroupContent() {
 				{pages.config && <GroupConfig />}
 				{pages.transactions &&
 					(sectionItem ? <GroupTransaction transactionId={sectionItem} /> : <GroupListTransactions />)}
+				{pages.settlement && <GroupSettlement />}
 				{pages.activity && <GroupActivity />}
 			</div>
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,5 +31,15 @@
   "Remaining": "Remaining",
   "Content not found": "Content not found",
   "Actions": "Actions",
-  "Activity Log": "Activity Log"
+  "Activity Log": "Activity Log",
+  "Banker": "Banker",
+  "BankerHint": "Holds the prepaid funds and pays out refunds",
+  "Settle up": "Settle up",
+  "Balances": "Balances",
+  "Transfers": "Transfers",
+  "gets back": "gets back",
+  "owes": "owes",
+  "settled": "settled",
+  "pays": "pays",
+  "Everyone is settled up": "Everyone is settled up — no transfers needed"
 }

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -31,5 +31,15 @@
   "Remaining": "Restante",
   "Content not found": "Conteúdo não encontrado",
   "Actions": "Ações",
-  "Activity Log": "Registro de Atividades"
+  "Activity Log": "Registro de Atividades",
+  "Banker": "Tesoureiro",
+  "BankerHint": "Guarda os valores depositados e devolve os reembolsos",
+  "Settle up": "Acerto de contas",
+  "Balances": "Saldos",
+  "Transfers": "Transferências",
+  "gets back": "a receber",
+  "owes": "a pagar",
+  "settled": "quitado",
+  "pays": "paga a",
+  "Everyone is settled up": "Tudo certo — nenhuma transferência necessária"
 }

--- a/frontend/src/pages/Group/Config.tsx
+++ b/frontend/src/pages/Group/Config.tsx
@@ -18,11 +18,13 @@ export function GroupConfig() {
 	const { data: group, updateGroup } = useGroupContext();
 	const [formFields, setFormFields] = useState<{ name: string }>({ name: '' });
 	const [members, setMembers] = useState<Member[]>([{ ...memberBase }]);
+	const [bankerId, setBankerId] = useState<string>('');
 	const { t } = useTranslation();
 
 	useEffect(() => {
 		setFormFields({ name: group.config?.name || '---' });
 		if (group.members) setMembers(group.members);
+		setBankerId(group.config?.bankerId || group.members?.[0]?.id || '');
 	}, [group]);
 
 	const memberName = 'memberName';
@@ -59,7 +61,8 @@ export function GroupConfig() {
 		updatedGroup = trackMemberChanges(updatedGroup, oldMembers, members);
 
 		// Apply the changes
-		updatedGroup.config = { ...updatedGroup.config, name: formFields.name };
+		const validBanker = members.some((m) => m.id === bankerId) ? bankerId : members[0]?.id;
+		updatedGroup.config = { ...updatedGroup.config, name: formFields.name, bankerId: validBanker };
 		updatedGroup.members = members;
 
 		updateGroup(updatedGroup);
@@ -85,6 +88,23 @@ export function GroupConfig() {
 							name="name"
 							onChange={handleFieldChange}
 						/>
+
+						<Label htmlFor="group-banker" className="mt-4 mb-2">
+							{t('Banker')}
+						</Label>
+						<select
+							id="group-banker"
+							value={bankerId}
+							onChange={(e) => setBankerId(e.target.value)}
+							className="border-input bg-background focus-visible:border-ring focus-visible:ring-ring/50 flex h-10 w-full rounded-md border px-3 py-2 text-base shadow-xs outline-none focus-visible:ring-[3px]"
+						>
+							{members.map((member) => (
+								<option key={member.id} value={member.id}>
+									{member.name || t('Name')}
+								</option>
+							))}
+						</select>
+						<p className="text-muted-foreground mt-1.5 text-xs">{t('BankerHint')}</p>
 					</CardContent>
 				</Card>
 

--- a/frontend/src/pages/Group/Settlement.tsx
+++ b/frontend/src/pages/Group/Settlement.tsx
@@ -1,0 +1,99 @@
+import { useTranslation } from 'react-i18next';
+import { ArrowRight, ArrowLeftRight } from 'lucide-react';
+
+import { useGroupContext } from '../../context/GroupContext';
+import { computeSettlement } from '../../utils/settlement';
+import { Avatar } from '../../components/Avatar';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+const SETTLED_EPS = 0.005;
+
+export function GroupSettlement() {
+	const { t } = useTranslation();
+	const { data: group } = useGroupContext();
+	const { balances, transfers, bankerId } = computeSettlement(group);
+
+	if (!group.members || group.members.length === 0) {
+		return (
+			<Card className="mx-auto max-w-md text-center">
+				<CardContent className="text-muted-foreground py-10">{t('No transactions found')}</CardContent>
+			</Card>
+		);
+	}
+
+	return (
+		<div className="grid gap-6 md:grid-cols-2">
+			<Card>
+				<CardHeader>
+					<CardTitle>{t('Balances')}</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-1">
+					{balances.map((b) => {
+						const settled = Math.abs(b.balance) < SETTLED_EPS;
+						const positive = b.balance > 0;
+						return (
+							<div
+								key={b.memberId}
+								className="border-border/60 flex items-center gap-3 border-b border-dashed py-2 last:border-0"
+							>
+								<Avatar name={b.name} className="size-8 text-xs" />
+								<span className="flex-1 truncate text-sm font-medium">
+									{b.name}
+									{b.memberId === bankerId && (
+										<Badge variant="muted" className="ml-2 align-middle">
+											{t('Banker')}
+										</Badge>
+									)}
+								</span>
+								<span
+									className={cn(
+										'tnum text-sm font-semibold',
+										settled ? 'text-muted-foreground' : positive ? 'text-primary' : 'text-foreground',
+									)}
+								>
+									{settled ? t('settled') : `$${Math.abs(b.balance)}`}
+								</span>
+								{!settled && (
+									<Badge variant={positive ? 'default' : 'secondary'}>{positive ? t('gets back') : t('owes')}</Badge>
+								)}
+							</div>
+						);
+					})}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>{t('Transfers')}</CardTitle>
+				</CardHeader>
+				<CardContent>
+					{transfers.length === 0 ? (
+						<div className="flex flex-col items-center gap-3 py-10 text-center">
+							<span className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-full">
+								<ArrowLeftRight className="size-7" />
+							</span>
+							<p className="text-muted-foreground">{t('Everyone is settled up')}</p>
+						</div>
+					) : (
+						<ul className="space-y-2">
+							{transfers.map((tr, i) => (
+								<li
+									key={`${tr.fromId}-${tr.toId}-${i}`}
+									className="border-border/60 flex items-center gap-2 rounded-lg border px-3 py-2.5"
+								>
+									<span className="truncate text-sm font-semibold">{tr.fromName}</span>
+									<span className="text-muted-foreground hidden text-xs sm:inline">{t('pays')}</span>
+									<ArrowRight className="text-muted-foreground size-4 shrink-0" />
+									<span className="truncate text-sm font-semibold">{tr.toName}</span>
+									<span className="tnum text-primary ml-auto font-semibold">${tr.amount}</span>
+								</li>
+							))}
+						</ul>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -41,6 +41,8 @@ export interface Activity {
 
 export interface GroupConfig {
 	name?: string;
+	/** Member who holds the prepaid pot; used by settlement. Defaults to the first member. */
+	bankerId?: string;
 }
 
 export interface Group {

--- a/frontend/src/utils/settlement.test.ts
+++ b/frontend/src/utils/settlement.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+
+import type { Group } from '../types';
+import { computeBalances, computeSettlement, type Transfer } from './settlement';
+
+function netTransfer(transfers: Transfer[], memberId: string): number {
+	let net = 0;
+	for (const t of transfers) {
+		if (t.toId === memberId) net += t.amount;
+		if (t.fromId === memberId) net -= t.amount;
+	}
+	return Math.round(net * 100) / 100;
+}
+
+function balanceOf(group: Group, memberId: string): number {
+	return computeBalances(group).find((b) => b.memberId === memberId)!.balance;
+}
+
+// The worked example from the design spec.
+const beachTrip: Group = {
+	config: { name: 'Beach Trip', bankerId: 'alice' },
+	members: [
+		{ id: 'alice', name: 'Alice', prepaid: 100 },
+		{ id: 'bob', name: 'Bob', prepaid: 0 },
+		{ id: 'carol', name: 'Carol', prepaid: 50 },
+	],
+	transactions: [
+		{
+			id: 't1',
+			date: '2026-06-14',
+			description: 'Dinner',
+			total: 120,
+			paidBy: { carol: 120 },
+			paidFor: { alice: 40, bob: 40, carol: 40 },
+		},
+	],
+};
+
+describe('computeBalances', () => {
+	it('computes prepaid + paidBy - paidFor per member', () => {
+		const balances = computeBalances(beachTrip);
+		const byId = Object.fromEntries(balances.map((b) => [b.memberId, b.balance]));
+		expect(byId).toEqual({ alice: 60, bob: -40, carol: 130 });
+	});
+
+	it('includes the member name', () => {
+		const alice = computeBalances(beachTrip).find((b) => b.memberId === 'alice');
+		expect(alice?.name).toBe('Alice');
+	});
+});
+
+describe('computeSettlement', () => {
+	it('settles every member to their fair share (banker holds the prepaid pot)', () => {
+		const { transfers, bankerId } = computeSettlement(beachTrip);
+		const pot = 150; // sum of prepaid
+		for (const m of beachTrip.members!) {
+			const effective = balanceOf(beachTrip, m.id) - (m.id === bankerId ? pot : 0);
+			// Each member's net cash movement must equal their effective balance.
+			expect(netTransfer(transfers, m.id)).toBeCloseTo(effective, 2);
+		}
+	});
+
+	it('produces at most n-1 transfers with positive amounts', () => {
+		const { transfers } = computeSettlement(beachTrip);
+		expect(transfers.length).toBeLessThanOrEqual(beachTrip.members!.length - 1);
+		expect(transfers.every((t) => t.amount > 0)).toBe(true);
+	});
+
+	it('returns no transfers when everyone is already even', () => {
+		const even: Group = {
+			config: { bankerId: 'a' },
+			members: [
+				{ id: 'a', name: 'A', prepaid: 0 },
+				{ id: 'b', name: 'B', prepaid: 0 },
+			],
+			transactions: [
+				{
+					id: 't1',
+					date: '2026-01-01',
+					description: 'x',
+					total: 100,
+					paidBy: { a: 50, b: 50 },
+					paidFor: { a: 50, b: 50 },
+				},
+			],
+		};
+		expect(computeSettlement(even).transfers).toEqual([]);
+	});
+
+	it('handles a single payer and single ower', () => {
+		const g: Group = {
+			config: { bankerId: 'a' },
+			members: [
+				{ id: 'a', name: 'A', prepaid: 0 },
+				{ id: 'b', name: 'B', prepaid: 0 },
+			],
+			transactions: [
+				{
+					id: 't1',
+					date: '2026-01-01',
+					description: 'x',
+					total: 100,
+					paidBy: { a: 100 },
+					paidFor: { a: 50, b: 50 },
+				},
+			],
+		};
+		expect(computeSettlement(g).transfers).toEqual([
+			{ fromId: 'b', fromName: 'B', toId: 'a', toName: 'A', amount: 50 },
+		]);
+	});
+
+	it('keeps cents balanced with non-even splits (no phantom transfers)', () => {
+		const g: Group = {
+			config: { bankerId: 'a' },
+			members: [
+				{ id: 'a', name: 'A', prepaid: 0 },
+				{ id: 'b', name: 'B', prepaid: 0 },
+				{ id: 'c', name: 'C', prepaid: 0 },
+			],
+			transactions: [
+				{
+					id: 't1',
+					date: '2026-01-01',
+					description: 'x',
+					total: 100,
+					paidBy: { a: 100 },
+					paidFor: { a: 33.33, b: 33.33, c: 33.34 },
+				},
+			],
+		};
+		const { transfers } = computeSettlement(g);
+		expect(transfers.every((t) => t.amount > 0)).toBe(true);
+		// Every member ends within a cent of their effective balance.
+		for (const m of g.members!) {
+			const effective = balanceOf(g, m.id) - (m.id === 'a' ? 0 : 0);
+			expect(netTransfer(transfers, m.id)).toBeCloseTo(effective, 2);
+		}
+	});
+
+	it('defaults the banker to the first member when bankerId is unset', () => {
+		const g: Group = {
+			config: {},
+			members: [
+				{ id: 'a', name: 'A', prepaid: 0 },
+				{ id: 'b', name: 'B', prepaid: 0 },
+			],
+			transactions: [],
+		};
+		expect(computeSettlement(g).bankerId).toBe('a');
+	});
+
+	it('does not throw and returns no transfers for an empty group', () => {
+		const empty: Group = { config: {} };
+		const result = computeSettlement(empty);
+		expect(result.transfers).toEqual([]);
+		expect(result.balances).toEqual([]);
+	});
+
+	it('produces at most n-1 transfers for a 10-member group', () => {
+		const members = Array.from({ length: 10 }, (_, i) => ({ id: `m${i}`, name: `M${i}`, prepaid: 0 }));
+		const paidFor = Object.fromEntries(members.map((m) => [m.id, 10]));
+		const g: Group = {
+			config: { bankerId: 'm0' },
+			members,
+			transactions: [{ id: 't1', date: '2026-01-01', description: 'x', total: 100, paidBy: { m0: 100 }, paidFor }],
+		};
+		const { transfers } = computeSettlement(g);
+		expect(transfers.length).toBeLessThanOrEqual(9);
+	});
+});

--- a/frontend/src/utils/settlement.ts
+++ b/frontend/src/utils/settlement.ts
@@ -1,0 +1,124 @@
+import type { Group } from '../types';
+
+export interface MemberBalance {
+	memberId: string;
+	name: string;
+	/** prepaid + paidBy − paidFor. Positive = owed money, negative = owes. */
+	balance: number;
+}
+
+export interface Transfer {
+	fromId: string;
+	fromName: string;
+	toId: string;
+	toName: string;
+	amount: number;
+}
+
+export interface SettlementResult {
+	balances: MemberBalance[];
+	transfers: Transfer[];
+	bankerId: string | null;
+}
+
+/** Amounts below this (half a cent) are treated as settled. */
+const EPS = 0.005;
+
+function round(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+/**
+ * Per-member balance: prepaid + everything they paid (paidBy) − everything they
+ * should be charged (paidFor), summed across all transactions.
+ */
+export function computeBalances(group: Group): MemberBalance[] {
+	const members = group.members ?? [];
+	const transactions = group.transactions ?? [];
+
+	return members.map((member) => {
+		let paidBy = 0;
+		let paidFor = 0;
+		for (const tx of transactions) {
+			paidBy += tx.paidBy?.[member.id] ?? 0;
+			paidFor += tx.paidFor?.[member.id] ?? 0;
+		}
+		return {
+			memberId: member.id,
+			name: member.name,
+			balance: round((member.prepaid ?? 0) + paidBy - paidFor),
+		};
+	});
+}
+
+interface EffectiveEntry {
+	id: string;
+	name: string;
+	amount: number;
+}
+
+/**
+ * Greedy min-cash-flow: repeatedly settle the largest debtor against the largest
+ * creditor. Produces at most n−1 transfers. Assumes amounts sum to ~0.
+ */
+function minimizeTransfers(entries: EffectiveEntry[]): Transfer[] {
+	const creditors = entries
+		.filter((e) => e.amount > EPS)
+		.map((e) => ({ ...e }))
+		.sort((a, b) => b.amount - a.amount);
+	const debtors = entries
+		.filter((e) => e.amount < -EPS)
+		.map((e) => ({ ...e, amount: -e.amount }))
+		.sort((a, b) => b.amount - a.amount);
+
+	const transfers: Transfer[] = [];
+	let i = 0;
+	let j = 0;
+	while (i < debtors.length && j < creditors.length) {
+		const debtor = debtors[i];
+		const creditor = creditors[j];
+		const amount = round(Math.min(debtor.amount, creditor.amount));
+		if (amount > EPS) {
+			transfers.push({
+				fromId: debtor.id,
+				fromName: debtor.name,
+				toId: creditor.id,
+				toName: creditor.name,
+				amount,
+			});
+		}
+		debtor.amount = round(debtor.amount - amount);
+		creditor.amount = round(creditor.amount - amount);
+		if (debtor.amount <= EPS) i++;
+		if (creditor.amount <= EPS) j++;
+	}
+	return transfers;
+}
+
+/**
+ * Compute balances and the fewest transfers to settle the group. The banker
+ * holds the prepaid pot (Σ prepaid), so their effective balance is reduced by
+ * it — which makes effective balances sum to zero and settle peer-to-peer.
+ */
+export function computeSettlement(group: Group): SettlementResult {
+	const members = group.members ?? [];
+	const balances = computeBalances(group);
+
+	if (members.length === 0) {
+		return { balances, transfers: [], bankerId: null };
+	}
+
+	const configuredBanker = group.config?.bankerId;
+	const bankerId =
+		configuredBanker && members.some((m) => m.id === configuredBanker) ? configuredBanker : members[0].id;
+
+	const pot = members.reduce((sum, m) => sum + (m.prepaid ?? 0), 0);
+
+	const effective: EffectiveEntry[] = balances.map((b) => ({
+		id: b.memberId,
+		name: b.name,
+		amount: round(b.balance - (b.memberId === bankerId ? pot : 0)),
+	}));
+
+	return { balances, transfers: minimizeTransfers(effective), bankerId };
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.ts'],
+	},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,8 @@
 				"tw-animate-css": "^1.4.0",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.61.0",
-				"vite": "^8.0.16"
+				"vite": "^8.0.16",
+				"vitest": "^4.1.8"
 			}
 		},
 		"frontend/node_modules/@rolldown/pluginutils": {
@@ -1179,6 +1180,13 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
@@ -1474,6 +1482,24 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/esrecurse": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1768,6 +1794,119 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.8",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.8",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.8",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.17.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1954,6 +2093,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/ast-types-flow": {
@@ -2159,6 +2308,16 @@
 				}
 			],
 			"license": "CC-BY-4.0"
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/class-variance-authority": {
 			"version": "0.7.1",
@@ -2534,6 +2693,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.2",
@@ -2965,6 +3131,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2973,6 +3149,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -4560,6 +4746,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4652,6 +4852,13 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5202,6 +5409,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5211,6 +5425,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
@@ -5400,6 +5628,23 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.17",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5433,6 +5678,16 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -5749,6 +6004,96 @@
 				}
 			}
 		},
+		"node_modules/vitest": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/void-elements": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -5861,6 +6206,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {


### PR DESCRIPTION
## Summary

Implements DivSplit's headline feature: per-member balances and the **fewest transfers** to settle a group, accounting for prepaid amounts.

- a pure, unit-tested settlement engine
- a **Settle up** tab showing balances and the transfer list
- a **Banker** selector in Config

## How it works

`balance(m) = prepaid(m) + paidBy(m) − paidFor(m)`.

Per transaction `paidBy` and `paidFor` net to zero, but prepaid adds cash that may not be fully consumed — so raw balances sum to the prepaid surplus, not zero.
One member is the **banker** who holds the prepaid pot, so their effective balance is reduced by `Σ prepaid`.
That makes effective balances sum to zero, and a greedy min-cash-flow (largest creditor ↔ largest debtor) yields the fewest transfers (≤ n−1).

Worked example — Alice (prepaid 100, banker), Bob (0), Carol (50), one $120 dinner paid by Carol, split 40/40/40:

```
net balances: Alice −90, Bob −40, Carol +130   (sum 0)
transfers:    Bob → Carol $40, Alice → Carol $90
```

## UI

- **Config:** a Banker dropdown writes `config.bankerId` (defaults to the first member).
- **Settle up tab:** a Balances panel (gets back / owes / settled, banker tagged) and a Transfers panel ("**X** pays **Y** `$Z`"), with an "everyone is settled up" empty state.

## Testing

- Adds **Vitest** (`npm test`); 11 unit tests cover the worked example, even groups, single payer, rounding residuals, banker default, net-balance invariants, and a 10-member transfer bound.
- `TEST.md` gains a Settle up section.

---

Design spec: `docs/superpowers/specs/2026-06-14-settlement-engine-design.md`
