### PR TITLE
fix(settlement): show net balances so they match the transfer list

### DIFF
--- a/frontend/src/pages/Group/Settlement.tsx
+++ b/frontend/src/pages/Group/Settlement.tsx
@@ -13,7 +13,7 @@ const SETTLED_EPS = 0.005;
 export function GroupSettlement() {
 	const { t } = useTranslation();
 	const { data: group } = useGroupContext();
-	const { balances, transfers, bankerId } = computeSettlement(group);
+	const { netBalances, transfers, bankerId } = computeSettlement(group);
 
 	if (!group.members || group.members.length === 0) {
 		return (
@@ -30,7 +30,7 @@ export function GroupSettlement() {
 					<CardTitle>{t('Balances')}</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-1">
-					{balances.map((b) => {
+					{netBalances.map((b) => {
 						const settled = Math.abs(b.balance) < SETTLED_EPS;
 						const positive = b.balance > 0;
 						return (

--- a/frontend/src/utils/settlement.test.ts
+++ b/frontend/src/utils/settlement.test.ts
@@ -60,6 +60,15 @@ describe('computeSettlement', () => {
 		}
 	});
 
+	it('exposes net balances (post-banker) that sum to zero and match the transfers', () => {
+		const { netBalances, transfers } = computeSettlement(beachTrip);
+		const sum = netBalances.reduce((acc, b) => acc + b.balance, 0);
+		expect(Math.abs(sum)).toBeLessThan(0.005);
+		for (const nb of netBalances) {
+			expect(netTransfer(transfers, nb.memberId)).toBeCloseTo(nb.balance, 2);
+		}
+	});
+
 	it('produces at most n-1 transfers with positive amounts', () => {
 		const { transfers } = computeSettlement(beachTrip);
 		expect(transfers.length).toBeLessThanOrEqual(beachTrip.members!.length - 1);

--- a/frontend/src/utils/settlement.ts
+++ b/frontend/src/utils/settlement.ts
@@ -16,7 +16,10 @@ export interface Transfer {
 }
 
 export interface SettlementResult {
+	/** Raw position per member: prepaid + paidBy − paidFor. */
 	balances: MemberBalance[];
+	/** Net position after the banker absorbs the prepaid pot; sums to ~0 and matches `transfers`. */
+	netBalances: MemberBalance[];
 	transfers: Transfer[];
 	bankerId: string | null;
 }
@@ -105,7 +108,7 @@ export function computeSettlement(group: Group): SettlementResult {
 	const balances = computeBalances(group);
 
 	if (members.length === 0) {
-		return { balances, transfers: [], bankerId: null };
+		return { balances, netBalances: [], transfers: [], bankerId: null };
 	}
 
 	const configuredBanker = group.config?.bankerId;
@@ -120,5 +123,11 @@ export function computeSettlement(group: Group): SettlementResult {
 		amount: round(b.balance - (b.memberId === bankerId ? pot : 0)),
 	}));
 
-	return { balances, transfers: minimizeTransfers(effective), bankerId };
+	const netBalances: MemberBalance[] = effective.map((e) => ({
+		memberId: e.id,
+		name: e.name,
+		balance: e.amount,
+	}));
+
+	return { balances, netBalances, transfers: minimizeTransfers(effective), bankerId };
 }


### PR DESCRIPTION
## Summary

Follow-up to #21. The Settle up **Balances** panel showed raw balances, which contradicted the transfers for the banker — e.g. a banker who prepaid the most appeared as "gets back $100" right next to a "pays $50" transfer.

Now `computeSettlement` exposes `netBalances` (post-banker, summing to zero), and the page renders those, so every balance row matches exactly what the transfers execute. Adds a unit test asserting net balances sum to zero and equal each member's net transfer.
