### PR TITLE
ci: run tests and build, and align Node to .nvmrc

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - "frontend/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".nvmrc"
+      - ".github/workflows/frontend.yml"
 
 permissions:
   pull-requests: write
@@ -18,7 +22,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           cache: 'npm'
 
       - name: Install dependencies
@@ -50,3 +54,24 @@ jobs:
       - name: Fail if linting fails
         if: steps.eslint.outputs.exitcode != 0
         run: exit 1
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Unit tests
+        run: npm test --workspace frontend
+
+      - name: Type-check and build
+        run: npm run build --workspace frontend


### PR DESCRIPTION
## Summary

CI only ran ESLint on a hardcoded Node 20, mismatching `.nvmrc` (24) and never exercising the type-check, build, or the new unit tests.

- use `node-version-file: .nvmrc` so CI tracks the project's Node version
- add a **test** job running the Vitest suite and `tsc -b && vite build`
- trigger the workflow on root `package*.json`, `.nvmrc`, and the workflow file too (not only `frontend/**`)
