### PR TITLE
feat(transactions): show inline validation instead of failing silently

### DIFF
--- a/frontend/src/pages/Group/Transaction.tsx
+++ b/frontend/src/pages/Group/Transaction.tsx
@@ -7,6 +7,7 @@ import { Wallet, HandCoins, Save, Check } from 'lucide-react';
 
 import { useGroupContext } from '../../context/GroupContext';
 import { trackTransactionCreated, trackTransactionUpdated } from '../../utils/activity-tracker';
+import { getTransactionError } from '../../utils/transaction';
 import type { AmountMap, Transaction } from '../../types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -47,6 +48,7 @@ export function GroupTransaction({ transactionId }: { transactionId: string }) {
 	const [description, setDescription] = useState<string>(existingTransaction?.description || '');
 	const [date, setDate] = useState<string>(formatDateForInput(existingTransaction?.date));
 	const manuallyChanged = useRef<Record<string, boolean>>(existingTransaction?.manuallyChanged || {});
+	const [error, setError] = useState<string | null>(null);
 
 	// Update state when transaction changes (e.g., navigating between transactions)
 	useEffect(() => {
@@ -113,15 +115,17 @@ export function GroupTransaction({ transactionId }: { transactionId: string }) {
 
 	function handleGroupSubmit(event: FormEvent<HTMLFormElement>) {
 		event.preventDefault();
+
+		const validationError = getTransactionError({ date, total, description });
+		if (validationError) {
+			setError(validationError);
+			return;
+		}
+		setError(null);
+
 		try {
-			if (!date || !total || !description) {
-				throw new Error('Please fill in all required fields');
-			}
 			let updatedGroup = { ...group };
 			const transactionDate = new Date(date);
-			if (isNaN(transactionDate.getTime())) {
-				throw new Error('Invalid date');
-			}
 			const isNew = transactionId === 'new';
 			const id = isNew ? String(new ObjectId()) : transactionId;
 
@@ -158,9 +162,9 @@ export function GroupTransaction({ transactionId }: { transactionId: string }) {
 			if (isNew) {
 				navigate(`/group/${groupId}/transactions/${id}`);
 			}
-		} catch (error) {
-			console.error('Error submitting group:', error);
-			// TODO: Implement error handling UI feedback
+		} catch (err) {
+			console.error('Error submitting transaction:', err);
+			setError('Something went wrong saving this transaction.');
 		}
 	}
 
@@ -316,7 +320,12 @@ export function GroupTransaction({ transactionId }: { transactionId: string }) {
 				</Card>
 			</div>
 
-			<div className="flex justify-end">
+			<div className="flex items-center justify-end gap-4">
+				{error && (
+					<p role="alert" className="text-destructive text-sm font-medium">
+						{error}
+					</p>
+				)}
 				<Button type="submit" size="lg">
 					<Save /> {t('Save')}
 				</Button>

--- a/frontend/src/utils/transaction.test.ts
+++ b/frontend/src/utils/transaction.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+import { getTransactionError } from './transaction';
+
+describe('getTransactionError', () => {
+	it('returns null when date, total and description are all present and valid', () => {
+		expect(getTransactionError({ date: '2026-06-14', total: 120, description: 'Dinner' })).toBeNull();
+	});
+
+	it('flags missing required fields', () => {
+		expect(getTransactionError({ date: '', total: 120, description: 'Dinner' })).toMatch(/date|total|description/i);
+		expect(getTransactionError({ date: '2026-06-14', total: 0, description: 'Dinner' })).toMatch(
+			/date|total|description/i,
+		);
+		expect(getTransactionError({ date: '2026-06-14', total: 120, description: '' })).toMatch(/date|total|description/i);
+	});
+
+	it('flags an unparseable date', () => {
+		expect(getTransactionError({ date: 'not-a-date', total: 120, description: 'Dinner' })).toMatch(/valid date/i);
+	});
+});

--- a/frontend/src/utils/transaction.ts
+++ b/frontend/src/utils/transaction.ts
@@ -1,0 +1,19 @@
+export interface TransactionInput {
+	date: string;
+	total: number;
+	description: string;
+}
+
+/**
+ * Validate the required transaction fields. Returns a human-readable error
+ * message, or null when the input is valid.
+ */
+export function getTransactionError({ date, total, description }: TransactionInput): string | null {
+	if (!date || !total || !description) {
+		return 'Please fill in the date, total and description.';
+	}
+	if (isNaN(new Date(date).getTime())) {
+		return 'Please enter a valid date.';
+	}
+	return null;
+}


### PR DESCRIPTION
## Summary

Saving a transaction with a missing date, total, or description (or an unparseable date) previously did nothing — the error was thrown and only logged to the console (there was a `TODO` for UI feedback).

Now a tested `getTransactionError` helper validates the input and its message is shown in red next to the Save button. Adds 3 unit tests for the helper.
