### PR TITLE
chore(ui): add brand favicon and clean up lint warnings

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -61,4 +61,12 @@ export default tseslint.config(
 			},
 		},
 	},
+	{
+		// shadcn/ui primitives export their cva variants next to the component by
+		// design; the fast-refresh rule doesn't apply to these generated files.
+		files: ['**/components/ui/**'],
+		rules: {
+			'react-refresh/only-export-components': 'off',
+		},
+	},
 );

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>DivSplit</title>
 	</head>
 	<body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+	<rect width="32" height="32" rx="8" fill="#d9531d" />
+	<g transform="translate(4 4)" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z" />
+	</g>
+</svg>


### PR DESCRIPTION
## Summary

- add an on-brand SVG favicon (self-hosted, removes the harmless page-load `404`)
- turn off `react-refresh/only-export-components` for `components/ui/**`, where shadcn primitives export their cva variants alongside the component by design

Lint is now warning-free.
