### PR TITLE
feat(settlement): mark transfers as paid

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Root scripts: `npm run dev`, `npm run format`, `npm run lint`. Frontend scripts 
 - `transaction.ts` — `getTransactionError` (form validation), unit-tested.
 - `activity-tracker.ts` — `ACTIVITY_TYPES` + pure functions appending audit entries (capped 100, newest first).
 - `tools.ts` — `jsonParseSafe` / `jsonStringifySafe`.
-- `types.ts` — shared domain types (`Group`, `Member`, `Transaction`, `Activity`, `Payment`, settlement types).
+- `types.ts` — shared domain types (`Group`, `Member`, `Transaction` incl. `TransactionType`, `Activity`, settlement types).
 
 **UI**
 - `components/ui/*` — shadcn primitives (`button`, `card`, `input`, `label`, `table`, `switch`, `badge`); `lib/utils.ts` exports `cn`.
@@ -140,13 +140,14 @@ All state is one **group object** per group id, stored in IndexedDB (typed in `t
 Group = {
   config:   { name?, bankerId? },          // bankerId = member holding the prepaid pot
   members:  Member[],                       // { id, name, prepaid }
-  transactions: Transaction[],              // expenses: { id, date, description, total,
-                                            //   paidBy:{memberId:amount}, paidFor:{memberId:amount},
-                                            //   manuallyChanged }
-  payments?: Payment[],                     // settle-up transfers: { id, fromId, toId, amount, date }
+  transactions: Transaction[],              // { id, type?: 'expense'|'transfer', date, description,
+                                            //   total, paidBy:{memberId:amount},
+                                            //   paidFor:{memberId:amount}, manuallyChanged }
   activities?: Activity[],                  // audit log (capped 100, newest first)
 }
 ```
+
+**Expenses vs. transfers are both `Transaction`s** (§1.1). An expense (`type` absent / `'expense'`) is consumption entered via the split form. A **transfer** (`type: 'transfer'`) is money between members — a settle-up (or, in future, prepaid) — with the *sender* on `paidBy` (credit) and *recipient* on `paidFor` (debit). Same shape, so it folds into balances for free; entered via the Settle up page, and filtered out of the expenses list.
 
 ### Auto-split (`Transaction.tsx`)
 Both `paidBy` and `paidFor` are `memberId → amount` maps. Toggling a member splits the remaining `total − sum(manually-typed)` equally across the others; rounding remainder lands on the current person so the parts reconcile to `total`. Most intricate code in the app.
@@ -155,10 +156,10 @@ Both `paidBy` and `paidFor` are `memberId → amount` maps. Toggling a member sp
 - `balance(m) = prepaid(m) + Σ paidBy − Σ paidFor + Σ (transfers given − received)`.
 - **Banker:** prepaid is currently a per-member number whose recipient is the **banker** (`config.bankerId`, default first member). The banker holds the pot, so their *effective* balance is reduced by `Σ prepaid`, making effective balances sum to zero.
 - `computeSettlement` runs a greedy **min-cash-flow** (largest creditor ↔ largest debtor) → fewest `transfers` (≤ n−1) plus `netBalances` (post-banker, sum to zero, match the transfers).
-- **Settle-up payments** (`payments`) fold straight into `computeBalances` (`balance(from) += amount`, `balance(to) -= amount`), so recording a payment makes that suggested transfer shrink/disappear.
+- **Settle-up** is recorded as a `type: 'transfer'` transaction, so it folds into `computeBalances` for free (sender `paidBy` +, recipient `paidFor` −); recording one shrinks/clears its suggested transfer. Undo deletes the transaction.
 
 ### Planned unification (project-owner rule, §1.1)
-Collapse `member.prepaid` (number) **and** `payments` into a single **`transfers: Transfer[]`** list (`{ id, fromId, toId, amount, kind: 'prepaid' | 'settlement', date }`). Prepaid becomes transfers *to the organizer*; the "banker" stops being a special case (it's just the recipient of prepaid transfers) and the pot adjustment + zero-sum fall out naturally. Until then, prepaid-as-number + banker is the live implementation.
+Prepaid is still a per-member number routed to the banker (mathematically equal to "everyone transferred their prepaid to the organizer"). The remaining step is to also express **prepaid as transfer transactions** to the organizer, retiring `member.prepaid` and the banker special-case so every balance is just `Σ(paidBy − paidFor)` over transactions. Settle-up already works this way.
 
 ---
 
@@ -172,7 +173,7 @@ React UI ──updateGroup(next)──► GroupContext ──► useApiGetGroup
 ```
 
 - **Write path:** a page builds a new group object (often via `activity-tracker` helpers), calls `updateGroup(next)`; `useApiGetGroup` stages it, persists, re-reads, and upserts the name into `groupList`.
-- **Derived, not stored:** balances and settlement transfers are computed on read from the group; only `payments` are persisted.
+- **Derived, not stored:** balances and the *suggested* settlement transfers are computed on read; recorded settle-ups are persisted as `type: 'transfer'` transactions.
 - **No network.** Fully offline; demo data from `/demo_data.json`.
 
 ---
@@ -200,8 +201,8 @@ React UI ──updateGroup(next)──► GroupContext ──► useApiGetGroup
 ## 10. Known Tech Debt & Code Hotspots
 
 - **`Transaction.tsx` auto-split** — complex in-place mutation + rounding; highest-risk hotspot, still untested at the component level (the pure split rules are the candidate to extract + unit-test).
-- **Prepaid model split** — prepaid (number) and settle-up (`payments`) should unify into one `transfers` list (§6); until then two shapes express the same concept.
-- **Inconsistent member ids** — members use `"${index}_${Date.now()}"` while transactions/payments/activities use ObjectId hex. Move members to UUIDs with the identity model.
+- **Prepaid still a number** — settle-up is now a transfer transaction, but prepaid remains `member.prepaid` + the banker special-case; express prepaid as transfer transactions too to retire the banker (§6).
+- **Inconsistent member ids** — members use `"${index}_${Date.now()}"` while transactions/activities use ObjectId hex. Move members to UUIDs with the identity model.
 - **`activities.userId` unused** — placeholder until the UUID identity model lands.
 - **No component/E2E tests** — only pure-logic unit tests exist.
 
@@ -212,8 +213,8 @@ React UI ──updateGroup(next)──► GroupContext ──► useApiGetGroup
 Source: project owner. Order indicative.
 
 1. ✅ **TypeScript migration**, dependency upgrades, **shadcn/Tailwind v4 redesign**, **CI** (lint+test+build), **settlement engine**.
-2. **Mark transfers as paid** *(in progress)* — record settle-up payments that net down balances; undoable; logged to Activity.
-3. **Unify prepaid + settle-up** into one member-to-member `transfers` model (§6), removing the banker special-case.
+2. ✅ **Mark transfers as paid** — settle-ups recorded as transfer transactions that net down balances; undoable; logged to Activity.
+3. **Finish unifying prepaid** — express prepaid as transfer transactions to the organizer too, removing `member.prepaid` and the banker special-case (§6).
 4. **Identity & privacy model** — per-event + per-member UUIDs so members contribute independently with no PII (§1.3); member identification in **v2**.
 5. **Backend sync layer** — local-first stays source of truth; reconcile multi-device offline edits (needs the UUID identities + conflict resolution).
 6. **Visual design via Stitch MCP** — generate fresh modern layouts, recorded in `DESIGN.md`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,48 +6,67 @@
 >
 > Keep this file current: update it in the same change that alters structure, the data model, routes, or a constraint. A stale architecture doc is worse than none.
 >
-> Project size: ~31 source files → documented at depth **L1**, with the **Monorepo** and **i18n** optional modules included because they apply.
+> Project size: ~40 source files → documented at depth **L1**, with the **Monorepo** and **i18n** optional modules included because they apply.
 
 ---
 
 ## 1. What DivSplit Is
 
-DivSplit is yet another shared-expense splitter for trips and group bills (restaurants, groceries, etc.). Two product decisions set it apart from typical splitters and shape the whole architecture:
+DivSplit is a shared-expense splitter for trips and group bills (restaurants, groceries, a rented lake-house, etc.). A few product decisions set it apart and shape the whole architecture.
 
-1. **Prepaid amounts.** When you create a group, each member can carry a **prepaid balance** — money already put in, like a pre-paid card (you must have funds to spend) rather than a credit card (pay later). Settlement must net expenses against these prepaid balances.
+### 1.1 Money in DivSplit: expenses vs. transfers
 
-2. **Decoupled "paid by" vs "paid for", with auto-split.** Each expense records, separately, *who actually paid* (`paidBy`) and *who should be charged* (`paidFor`). These need not match — e.g. the person with cash pays the street-food vendor, but a different person actually eats the food. When the user types an amount for one person, the remaining total auto-splits across the other selected people, so nobody does mental arithmetic.
+There are exactly **two kinds of money movement**, and keeping them distinct is the core domain model:
 
-3. **Fewest-transfers settlement (planned).** The long-term goal is to net everyone's balances and emit the *minimum* set of transfers, so a 10-person trip never ends with one person sending money to nine others. **This settlement engine is not implemented yet** — the data is captured, the computation is future work (see §9 and §11).
+1. **Expenses** (`transactions`) — *consumption*. Each records, separately, *who actually paid* (`paidBy`) and *who should be charged* (`paidFor`); these need not match (the person with cash pays the street-food vendor, but someone else eats the food). An auto-split helper fills in the rest so nobody does mental arithmetic (§6).
 
-**Local-first by design.** The app must run with **no internet** (trips often have none). All data persists to the browser. A backend/database is intentionally deferred and will act as a **sync layer** *after* local save — allowing multiple users to record transactions offline on their own devices and reconcile later.
+2. **Transfers** — money one member hands another that is **not** an expense, but still moves their balances. This single primitive covers two product features that are conceptually the same thing:
+   - **Prepaid** — money members put in up front, typically to one organizer. Example: ten friends rent a lake-house; one person makes the booking and pays, so everyone wires **them** first. The organizer waits until everyone has paid in before committing, and isn't left out of pocket if some people flake. That collected money sits in the organizer's balance, ready to be drawn down by the lake-house expense.
+   - **Settle-up** — a debtor paying a creditor to clear the balance the app computed (during or at the end of the trip).
+
+   **Rule (project owner):** prepaid and settle-up are the same concept — "A gave B money, counts toward balances, is not an expense." The target model collapses both into one **member-to-member transfer** list (§6). A pleasant consequence: with transfers and expenses both balanced, every member balance sums to zero, so settlement is pure peer-to-peer with no special "banker pot" handling.
+
+### 1.2 Fewest-transfers settlement
+
+The app nets everyone's balances and emits the **minimum** set of transfers, so a 10-person trip never ends with one person paying nine others. **Built** (`utils/settlement.ts`, §6).
+
+### 1.3 Local-first & privacy
+
+- **Local-first by design.** The app must run with **no internet** (trips often have none). All data persists in the browser. A backend/database is intentionally deferred and will act as a **sync layer** *after* local save — letting multiple people record on their own devices offline and reconcile later. Fonts are self-hosted and avatars generated locally so nothing breaks offline.
+- **Privacy by default (project owner rule).** No email or personal data is required — it stays optional, to protect people's privacy. Identity is modeled with opaque UUIDs, not accounts:
+  - each **event** (group) has a UUID the creator shares with members;
+  - each **member** gets their own per-event UUID;
+  - a member uses their UUID to record expenses **independently**, without waiting for the creator — this is what later enables multi-device offline contribution.
+  - Real **member identification/auth is a v2 concern**; today there is no PII and `activities.userId` is unused.
 
 ---
 
 ## 2. Stack & Dependencies
 
-**Monorepo** managed with **npm workspaces** (`frontend`, `backend`). Node **24** (`.nvmrc`). ES modules throughout (`"type": "module"`).
+**Monorepo** managed with **npm workspaces** (`frontend`, `backend`). Node **24** (`.nvmrc`). ES modules throughout (`"type": "module"`). The frontend is **TypeScript** (strict).
 
 ### Frontend (`frontend/`) — the only live workspace today
 | Concern | Choice |
 |---|---|
-| Build / dev server | **Vite 5** (`@vitejs/plugin-react`) |
-| UI | **React 19** + **react-dom 19** |
-| Routing | **react-router-dom 6** |
-| Styling | **Tailwind CSS 3** + **daisyUI 4** + `@tailwindcss/typography` |
+| Language | **TypeScript 6** (strict; project references) |
+| Build / dev server | **Vite 8** (`@vitejs/plugin-react` 6) |
+| UI | **React 19.2** + **react-dom** |
+| Routing | **react-router-dom 7** |
+| Styling | **Tailwind CSS v4** (`@tailwindcss/vite`, CSS-first `@theme`) + **shadcn/ui** primitives |
+| Icons | **lucide-react** |
+| Fonts | self-hosted via **@fontsource** (Fraunces / Hanken Grotesk / JetBrains Mono) |
 | i18n | **i18next** + **react-i18next** + browser language detector |
 | Local persistence | **localforage** (IndexedDB) |
-| ID generation | **bson-objectid** (Mongo-style ObjectIds, for an eventual DB) |
-| Icons | **react-icons** |
-| Prop validation | **prop-types** (runtime; no TypeScript yet) |
+| ID generation | **bson-objectid** (Mongo-style ObjectIds) |
+| Unit tests | **Vitest** |
 
 ### Backend (`backend/`)
-Placeholder workspace. `package.json` is empty (`{}`). No code yet — reserved for the future sync layer.
+Placeholder workspace (`package.json` is `{}`). Reserved for the future sync layer.
 
 ### Tooling
-ESLint 9 (flat config) + Prettier (`.prettierrc.yml`), run from root. Deployed on **Vercel** (`vercel.json`).
+**ESLint 10** (flat config) + **typescript-eslint** + **Prettier**. CI (`.github/workflows/frontend.yml`) runs **lint**, **unit tests**, and **type-check + build** on the Node version from `.nvmrc`. Deployed on **Vercel** (`vercel.json`).
 
-> ⚠️ **Version mismatch:** `.nvmrc` pins Node **24** but `.github/workflows/frontend.yml` uses Node **20**. Align these when touching CI.
+> Note: `eslint` is pinned via a root `overrides` because `eslint-plugin-react` 7.37 doesn't yet declare ESLint 10 support; the React version is also pinned in the flat config to avoid its removed-API crash on ESLint 10.
 
 ---
 
@@ -55,103 +74,91 @@ ESLint 9 (flat config) + Prettier (`.prettierrc.yml`), run from root. Deployed o
 
 ```
 divsplit/
-├─ package.json          # root: workspaces, shared dev tooling (eslint, prettier), scripts
+├─ package.json          # root: workspaces, shared dev tooling, eslint override, scripts
 ├─ vercel.json           # builds frontend workspace, SPA rewrite → index.html
-├─ frontend/             # Vite + React 19 SPA (all current application code)
+├─ frontend/             # Vite + React 19 + TS SPA (all current application code)
 ├─ backend/              # empty placeholder workspace (future sync API)
 ├─ ARCHITECTURE.md       # this file
 ├─ DESIGN.md             # visual design system (placeholder; to be built via Stitch MCP)
-└─ .github/              # CI (frontend lint) + copilot-instructions.md
+├─ TEST.md               # manual QA procedures per feature
+├─ docs/superpowers/specs # design specs (settlement, mark-as-paid, …)
+└─ .github/              # CI (lint + test + build) + copilot-instructions.md
 ```
 
-Root scripts: `npm run dev` → frontend dev server; `npm run format` → Prettier; `npm run lint` → ESLint + frontend lint.
+Root scripts: `npm run dev`, `npm run format`, `npm run lint`. Frontend scripts add `build` (`tsc -b && vite build`), `test` (`vitest run`), `typecheck`.
 
 ---
 
 ## 4. Module Map (`frontend/src`)
 
 **Entry & shell**
-- `renderApp.jsx` — bootstrap only; mounts `<App/>` into `#app-root` under `React.StrictMode`. (By convention, no logic here.)
-- `App.jsx` — composition root: `ThemeProvider → Container → AppRouter`; loads `App.css` and `i18n`.
-- `routes/AppRouter.jsx` — `BrowserRouter`, global `Header`, and the route table (see §5).
+- `renderApp.tsx` — bootstrap only; mounts `<App/>` into `#app-root` under `StrictMode`.
+- `App.tsx` — composition root: imports `index.css` + fonts + i18n; `ThemeProvider → Container → AppRouter`.
+- `routes/AppRouter.tsx` — `BrowserRouter`, global `Header`, route table (§5).
+- `index.css` — Tailwind v4 entry: theme tokens (oklch, light/dark), fonts, base styles.
 
 **Cross-cutting state (React Context)**
-- `context/ThemeContext.jsx` — light/dark theme, persisted to `localStorage["divsplit_theme"]`.
-- `context/GroupContext.jsx` — loads and exposes the active group (`data`, `updateGroup`, `loadDemo`) for the current `:groupId`; renders `<Loading/>` while fetching.
+- `context/ThemeContext.tsx` — light/dark, persisted to `localStorage["divsplit_theme"]`; toggles the `.dark` class on `<html>`.
+- `context/GroupContext.tsx` — loads/exposes the active group (`data`, `updateGroup`, `loadDemo`).
 
-**Data layer**
-- `utils/use-api.js` — the persistence boundary. localforage instances `groupList` and `group`; hooks `useApiListGroups`, `useApiGetGroup`; `loadDemoData`; `generateId()` (ObjectId). *This is the single place that touches storage — treat it as the "API" the rest of the app talks to.*
-- `utils/activity-tracker.js` — `ACTIVITY_TYPES` enum + pure functions that append audit entries to a group (capped at 100, newest first).
-- `utils/tools.js` — `jsonParseSafe` / `jsonStringifySafe`.
+**Domain & data layer (`utils/`)**
+- `use-api.ts` — the persistence boundary. localforage stores `groupList` and `group`; hooks `useApiListGroups`, `useApiGetGroup`; `loadDemoData`; `generateId()`. *Single place that touches storage.*
+- `settlement.ts` — **pure** settlement engine: `computeBalances` and `computeSettlement` (balances → banker pot adjustment → greedy min-cash-flow → fewest `transfers` + `netBalances`). Unit-tested.
+- `transaction.ts` — `getTransactionError` (form validation), unit-tested.
+- `activity-tracker.ts` — `ACTIVITY_TYPES` + pure functions appending audit entries (capped 100, newest first).
+- `tools.ts` — `jsonParseSafe` / `jsonStringifySafe`.
+- `types.ts` — shared domain types (`Group`, `Member`, `Transaction`, `Activity`, `Payment`, settlement types).
 
-**Pages**
-- `pages/HomePage.jsx` — landing; lists groups via `CardGroup`/`CardContainer`.
-- `pages/Group/Config.jsx` — edit group name + members (name, prepaid); diffs old vs new and records activities.
-- `pages/Group/Transaction.jsx` — create/edit a transaction; **hosts the auto-split algorithm** (see §6).
-- `pages/Group/ListTransactions.jsx` — transaction table; row links + delete (records activity).
-- `pages/Group/Activity.jsx` — activity feed with relative timestamps.
-- `pages/NotFound.jsx`.
-
-**Components**
-- `components/GroupPageWrapper.jsx` — wraps a group route in `GroupProvider`, dispatches the `:section` to the right page, shows the "load sample data" prompt for empty groups, and mounts `Debug`.
-- `Header`, `GroupHeader`, `Avatar`, `Hr`, `Loading`, `Container`, `CardGroup`, `CardContainer`, `Debug`.
+**UI**
+- `components/ui/*` — shadcn primitives (`button`, `card`, `input`, `label`, `table`, `switch`, `badge`); `lib/utils.ts` exports `cn`.
+- Pages (`pages/`): `HomePage`, `Group/Config`, `Group/Transaction` (hosts auto-split), `Group/ListTransactions`, `Group/Settlement`, `Group/Activity`, `NotFound`.
+- `components/GroupPageWrapper.tsx` — wraps a group route in `GroupProvider`, dispatches `:section`, shows the empty-group prompt, mounts `Debug`.
+- `Header`, `GroupHeader` (tab nav), `Avatar` (local initials), `Hr`, `Loading`, `Container`, `CardGroup`, `CardContainer`, `Debug`.
 
 ---
 
 ## 5. Route Structure
 
-SPA, client-side routing only (Vercel rewrites all paths to `index.html`).
+SPA, client-side routing only (Vercel rewrites all paths to `index.html`). The single dynamic route is `/group/:groupId/:section/:sectionItem?`; `GroupPageWrapper` switches on `section`.
 
 | Path | Renders |
 |---|---|
 | `/` | `HomePage` (group list) |
-| `/group/:groupId/config` | `GroupConfig` |
-| `/group/:groupId/transactions` | `GroupListTransactions` |
-| `/group/:groupId/transactions/:sectionItem` | `GroupTransaction` (`:sectionItem` = transaction id, or `new`) |
+| `/group/:groupId/config` | `GroupConfig` (name, members, prepaid, banker) |
+| `/group/:groupId/transactions[/:id\|new]` | transactions list / `GroupTransaction` |
+| `/group/:groupId/settlement` | `GroupSettlement` (balances + transfers) |
 | `/group/:groupId/activity` | `GroupActivity` |
 | `*` | `NotFound` |
-
-The single dynamic route is `/group/:groupId/:section/:sectionItem?`; `GroupPageWrapper` switches on `section` (`config` / `transactions` / `activity`).
 
 ---
 
 ## 6. Data Model & Core Domain Logic
 
-All state is one **group object** per group id, stored in IndexedDB.
+All state is one **group object** per group id, stored in IndexedDB (typed in `types.ts`).
 
-```jsonc
-group = {
-  config:   { name },                 // canonical group name
-  members:  [ { id, name, prepaid } ],// prepaid = pre-funded balance (number)
-  transactions: [ {
-    id,                               // ObjectId hex
-    date, createdAt | updatedAt,
-    description, total,
-    paidBy:  { [memberId]: amount },  // who actually paid
-    paidFor: { [memberId]: amount },  // who is charged / consumed
-    manuallyChanged: { [memberId]: true } // entries the user typed → exempt from auto-split
-  } ],
-  activities: [ {                     // audit log, newest first, capped at 100
-    id, type, description, details, userId /* always null today */, timestamp
-  } ]
+```ts
+Group = {
+  config:   { name?, bankerId? },          // bankerId = member holding the prepaid pot
+  members:  Member[],                       // { id, name, prepaid }
+  transactions: Transaction[],              // expenses: { id, date, description, total,
+                                            //   paidBy:{memberId:amount}, paidFor:{memberId:amount},
+                                            //   manuallyChanged }
+  payments?: Payment[],                     // settle-up transfers: { id, fromId, toId, amount, date }
+  activities?: Activity[],                  // audit log (capped 100, newest first)
 }
 ```
 
-> Demo data (`frontend/demo_data.json`) also carries a legacy `header.name`; the live UI uses `config.name`.
+### Auto-split (`Transaction.tsx`)
+Both `paidBy` and `paidFor` are `memberId → amount` maps. Toggling a member splits the remaining `total − sum(manually-typed)` equally across the others; rounding remainder lands on the current person so the parts reconcile to `total`. Most intricate code in the app.
 
-### The auto-split algorithm (`Transaction.jsx › handleMemberChange`)
-Both `paidBy` and `paidFor` are `memberId → amount` maps and use the same logic:
+### Settlement (`settlement.ts`) — **built & tested**
+- `balance(m) = prepaid(m) + Σ paidBy − Σ paidFor + Σ (transfers given − received)`.
+- **Banker:** prepaid is currently a per-member number whose recipient is the **banker** (`config.bankerId`, default first member). The banker holds the pot, so their *effective* balance is reduced by `Σ prepaid`, making effective balances sum to zero.
+- `computeSettlement` runs a greedy **min-cash-flow** (largest creditor ↔ largest debtor) → fewest `transfers` (≤ n−1) plus `netBalances` (post-banker, sum to zero, match the transfers).
+- **Settle-up payments** (`payments`) fold straight into `computeBalances` (`balance(from) += amount`, `balance(to) -= amount`), so recording a payment makes that suggested transfer shrink/disappear.
 
-1. Toggling a member on adds them at `0`; toggling off deletes them.
-2. Entries the user **typed into** are recorded in the `manuallyChanged` ref and held **fixed**.
-3. The **remaining** amount (`total − sum(manual)`) is split **equally** across the non-manual selected members.
-4. Any rounding remainder (values are rounded to 2 decimals via `round()`) is absorbed by the current person so the sum reconciles to `total`.
-5. `getRemainingValue()` surfaces `total − sum` per fieldset as live feedback.
-
-This is the **most intricate and fragile code in the app** (it mutates the working map in place before re-setting state). Touch it carefully; it is the prime candidate for unit tests once a test setup exists.
-
-### Not yet modeled
-- **Balances & settlement.** Per-member net balance (prepaid + paidBy − paidFor) and the minimal-transfer plan are **not computed anywhere yet**. Transactions capture the raw inputs the future engine will need.
+### Planned unification (project-owner rule, §1.1)
+Collapse `member.prepaid` (number) **and** `payments` into a single **`transfers: Transfer[]`** list (`{ id, fromId, toId, amount, kind: 'prepaid' | 'settlement', date }`). Prepaid becomes transfers *to the organizer*; the "banker" stops being a special case (it's just the recipient of prepaid transfers) and the pot adjustment + zero-sum fall out naturally. Until then, prepaid-as-number + banker is the live implementation.
 
 ---
 
@@ -164,56 +171,55 @@ React UI ──updateGroup(next)──► GroupContext ──► useApiGetGroup
                                           localforage "groupList" (name index)
 ```
 
-- **Two stores:** `group` (full object keyed by `groupId`) and `groupList` (lightweight `[{id, name}]` index for the home page).
-- **Write path:** a page builds a new group object (often via `activity-tracker` helpers), calls `updateGroup(next)`. `useApiGetGroup` stages it as `dataToSave`, an effect persists it, re-reads, and mirrors the name into `groupList`.
-- **Demo data:** `loadDemoData` fetches `/demo_data.json` (served from `frontend/demo_data.json`) into the `group` store and registers it in `groupList`. `useApiListGroups` also seeds three placeholder groups on first run.
-- **No network.** Everything is in-browser; the app works fully offline.
+- **Write path:** a page builds a new group object (often via `activity-tracker` helpers), calls `updateGroup(next)`; `useApiGetGroup` stages it, persists, re-reads, and upserts the name into `groupList`.
+- **Derived, not stored:** balances and settlement transfers are computed on read from the group; only `payments` are persisted.
+- **No network.** Fully offline; demo data from `/demo_data.json`.
 
 ---
 
 ## 8. Configuration & Environment
 
-- **`VITE_SHOW_DEBUG=true`** — renders the `Debug` panel (raw group JSON) on group pages.
-- **i18n detection order:** querystring `?lang=`, `localStorage["i18nLang"]`, then browser `navigator`; fallback `en`. Locales: `en`, `pt` (`src/locales/*.json`); `load: 'languageOnly'`.
-- **Theme:** persisted at `localStorage["divsplit_theme"]`; daisyUI themes `light` / `dark`.
-- **Vite aliases:** `@`, `@components`, `@context`, `@pages`, `@utils`, `@routes`, `@locales` → `src/*`.
-- **Deploy (Vercel):** build `npm run build --workspace frontend` → `frontend/dist`; SPA rewrite `/(.*) → /index.html`.
+- **`VITE_SHOW_DEBUG=true`** — renders the `Debug` raw-group panel on group pages.
+- **i18n:** detection order querystring `?lang=` → `localStorage["i18nLang"]` → navigator; fallback `en`. Locales `en`, `pt`.
+- **Theme:** `.dark` class on `<html>`; tokens defined in `index.css` (oklch); persisted at `localStorage["divsplit_theme"]`.
+- **Vite aliases:** `@`, `@components`, `@context`, `@pages`, `@utils`, `@routes`, `@locales` → `src/*` (mirrored in `tsconfig`).
+- **Deploy (Vercel):** build `npm run build --workspace frontend` → `frontend/dist`; SPA rewrite.
 
 ---
 
 ## 9. Constraints & Trade-offs
 
-- **Local-first, intentionally.** No backend persistence today — required so trips without internet still work. The `backend/` workspace is an empty placeholder.
-- **Single-device today.** Data lives in *one* browser's IndexedDB. Multi-device/multi-user **sync is a future goal**, not a current capability. Designing the sync layer will need stable identities (today `activities.userId` is always `null`) and conflict resolution.
-- **No settlement engine yet.** The headline "fewest transfers" feature is unbuilt (§6, §11).
-- **No tests.** No test runner is configured; the riskiest code (auto-split) is untested.
-- **JavaScript + PropTypes**, not TypeScript (migration planned, §11).
+- **Local-first, intentionally.** No backend persistence today; `backend/` is an empty placeholder.
+- **Single-device today.** Data lives in one browser's IndexedDB. Multi-device/multi-user **sync is a future goal** built on the UUID identity model (§1.3) + conflict resolution.
+- **No PII.** Identity is opaque per-event UUIDs; member identification is deferred to v2.
+- **Greedy settlement** (near-optimal), not provably minimal.
+- **Tests cover pure logic** (settlement, validation) via Vitest; UI is covered by manual `TEST.md` + Chrome MCP QA, not component tests yet.
 
 ---
 
 ## 10. Known Tech Debt & Code Hotspots
 
-- **`Transaction.jsx › handleMemberChange`** — complex in-place mutation + rounding; highest-risk hotspot. Cover with tests before refactoring.
-- **Inconsistent member ids** — members use `"${index}_${Date.now()}"` while groups/transactions/activities use ObjectId hex. Unify before the DB/sync layer relies on ids.
-- **Node version drift** — `.nvmrc` (24) vs CI (20). See §2.
-- **Mixed-language comments** (Portuguese/English) across files.
-- **Unfinished UI affordances** — the home page "create group" button has no handler; `Transaction.jsx` submit has a `// TODO` for error-handling UI.
-- **`activities.userId` unused** (always `null`) — placeholder for future auth/identity.
+- **`Transaction.tsx` auto-split** — complex in-place mutation + rounding; highest-risk hotspot, still untested at the component level (the pure split rules are the candidate to extract + unit-test).
+- **Prepaid model split** — prepaid (number) and settle-up (`payments`) should unify into one `transfers` list (§6); until then two shapes express the same concept.
+- **Inconsistent member ids** — members use `"${index}_${Date.now()}"` while transactions/payments/activities use ObjectId hex. Move members to UUIDs with the identity model.
+- **`activities.userId` unused** — placeholder until the UUID identity model lands.
+- **No component/E2E tests** — only pure-logic unit tests exist.
 
 ---
 
 ## 11. Roadmap / Future Direction
 
-Captured here because it directly shapes architectural decisions (source: project owner). Order is indicative, not committed.
+Source: project owner. Order indicative.
 
-1. **Settlement engine** — compute per-member balances (prepaid + paidBy − paidFor) and emit the **minimum-transfer** plan.
-2. **Backend sync layer** — local-first stays the source of truth; the backend reconciles multiple users' offline edits when a device regains internet (needs identities + conflict resolution).
-3. **TypeScript migration** — replace PropTypes with static types (note `@types/react*` are already present).
-4. **Dependency upgrades** — React and all other npm dependencies bumped to current.
-5. **Visual redesign** — a fresh, distinctive look (the current UI is generic). Design system to be produced via the **Stitch MCP** and recorded in `DESIGN.md`.
+1. ✅ **TypeScript migration**, dependency upgrades, **shadcn/Tailwind v4 redesign**, **CI** (lint+test+build), **settlement engine**.
+2. **Mark transfers as paid** *(in progress)* — record settle-up payments that net down balances; undoable; logged to Activity.
+3. **Unify prepaid + settle-up** into one member-to-member `transfers` model (§6), removing the banker special-case.
+4. **Identity & privacy model** — per-event + per-member UUIDs so members contribute independently with no PII (§1.3); member identification in **v2**.
+5. **Backend sync layer** — local-first stays source of truth; reconcile multi-device offline edits (needs the UUID identities + conflict resolution).
+6. **Visual design via Stitch MCP** — generate fresh modern layouts, recorded in `DESIGN.md`.
 
 ---
 
-## 12. Security
+## 12. Security & Privacy
 
-Client-only app: no auth, no secrets, no server. Data is confined to the user's browser storage. Security surface is minimal today but becomes material with the sync layer (§11) — that work will introduce authentication, transport security, and per-user authorization, and must be re-assessed here when it lands.
+Client-only app: no auth, no secrets, no server; data confined to browser storage. **Privacy is a product principle** — no email/PII is collected; identity is opaque UUIDs (§1.3). The security/privacy surface becomes material with the sync layer (§11), which will introduce transport security, per-user authorization, and conflict handling, and must be re-assessed here when it lands.

--- a/TEST.md
+++ b/TEST.md
@@ -43,11 +43,12 @@ Most tests below use this group:
 
 ### TC-1.1 — Home page renders
 
-1. Open http://localhost:5173/.
+1. Open http://localhost:5173/ on a **fresh profile** (or incognito).
 2. **Expected:** hero with the title "Split your group expenses with ease" and a
-   **new group** button. Below, "Your expense management groups" lists existing
-   group cards (three seeded `Grupo Teste` cards on a fresh profile). The browser
-   console has no errors.
+   **new group** button. With no groups yet, an empty-state card shows
+   "No groups yet — create your first one" and a **new group** button (no fake
+   seeded groups). The browser console has no errors.
+3. After creating groups, they list under "Your expense management groups".
 
 ### TC-1.2 — Create a new group
 
@@ -243,6 +244,21 @@ pure logic is also covered by unit tests: `npm test --workspace frontend`.
 1. A group where each member's contributions equal their consumption.
 2. **Expected:** all rows show "settled" and the Transfers panel shows
    "Everyone is settled up — no transfers needed".
+
+### TC-7.5 — Mark a transfer as paid
+
+1. With a suggested transfer (e.g. `Alice → Carol $50`), click **Mark paid**.
+2. **Expected:** a settle-up is recorded — the transfer leaves the suggested list,
+   the involved members move toward "settled", and the payment appears under
+   **Recorded payments** (`from → to · amount · date`). The Activity tab logs
+   "{from} paid {to} $X". The settle-up does **not** appear in the Transactions
+   (expenses) list.
+
+### TC-7.6 — Undo a recorded payment
+
+1. In **Recorded payments**, click **Undo** on an entry.
+2. **Expected:** the payment is removed, the balance/transfer it cleared comes
+   back, and Activity logs "Removed payment: {from} → {to} $X".
 
 ---
 

--- a/docs/superpowers/specs/2026-06-14-mark-transfers-paid-design.md
+++ b/docs/superpowers/specs/2026-06-14-mark-transfers-paid-design.md
@@ -2,6 +2,14 @@
 
 > Status: approved (2026-06-14). Lets users record settle-up transfers as paid so
 > the suggested-transfers list reflects what has actually been settled.
+>
+> **Revision (during implementation):** instead of a separate `payments[]` array,
+> a settle-up is stored as a **`Transaction` of `type: 'transfer'`** (project-owner
+> rule: "a transfer is just a transaction"). Sender → `paidBy` (credit), recipient
+> → `paidFor` (debit), so it folds into `computeBalances` with no new settlement
+> code and no `Payment` type. Everything below about balance effects still holds;
+> just read "payment" as "transfer transaction". Transfers are filtered out of the
+> expenses list and managed on the Settle up page.
 
 ## Goal
 

--- a/docs/superpowers/specs/2026-06-14-mark-transfers-paid-design.md
+++ b/docs/superpowers/specs/2026-06-14-mark-transfers-paid-design.md
@@ -1,0 +1,81 @@
+# Mark transfers as paid — design
+
+> Status: approved (2026-06-14). Lets users record settle-up transfers as paid so
+> the suggested-transfers list reflects what has actually been settled.
+
+## Goal
+
+On the Settle up page, suggested transfers are derived from balances and have no
+stable identity. Let a user mark a transfer paid in a way that:
+
+- survives recomputation when expenses or members change,
+- keeps the suggested-transfers list correct (paid transfers drop out),
+- is undoable, and leaves a record of what was paid.
+
+## Model: record a payment
+
+Marking "Bob pays Carol $40" appends a **payment** that feeds back into balances —
+the same approach as Splitwise's "settle up". Payments are settlement money
+movements, kept **separate from expenses** (the Transactions list stays
+expenses-only).
+
+```ts
+interface Payment {
+	id: string;
+	fromId: string;
+	toId: string;
+	amount: number;
+	date: string | Date;
+}
+// Group gains: payments?: Payment[]
+```
+
+### Settlement integration (`settlement.ts`)
+
+`computeBalances` folds payments into each member's balance after the
+prepaid/paidBy/paidFor sum:
+
+```
+for each payment p:
+	balance(p.fromId) += p.amount   // paying reduces the payer's outstanding debt
+	balance(p.toId)   -= p.amount   // receiving reduces the payee's credit
+```
+
+The banker pot adjustment and greedy min-cash-flow are unchanged, so the
+suggested `transfers` automatically shrink or disappear as payments are recorded,
+and `netBalances` stay consistent. No new identity/flag plumbing is needed.
+
+## Recording and undo
+
+- **Mark paid:** each suggested transfer row gets a button that appends a
+  `Payment` (`fromId`, `toId`, `amount`, `date = now`, generated `id`) to
+  `group.payments` via `updateGroup`.
+- **Undo:** a **Recorded payments** section lists payments (`from → to · amount ·
+  date`), each with a delete button that removes it from `group.payments`.
+- **Activity:** both actions append an Activity entry. Add
+  `PAYMENT_RECORDED` and `PAYMENT_REMOVED` to `ACTIVITY_TYPES`, with
+  `trackPaymentRecorded` / `trackPaymentRemoved` helpers, so settle-ups show in
+  the Activity tab and respect the existing 100-entry cap.
+
+## UI (Settle up page)
+
+- Each transfer row: existing "**X** pays **Y** `$Z`" plus a **Mark paid** button
+  (check icon).
+- Below the transfers, a **Recorded payments** card/list (only shown when there
+  are payments) with per-row **Undo**.
+- The existing "Everyone is settled up" empty state still applies once balances
+  net out (whether via real evenness or recorded payments).
+
+## Testing
+
+- **Unit (TDD, `settlement.test.ts`):** payments adjust balances in the right
+  direction; recording the suggested transfers as payments drives all balances to
+  settled (no remaining transfers); a partial payment reduces but doesn't clear.
+- **Activity:** `activity-tracker` payment helpers covered by a focused test.
+- **Live QA (Chrome MCP):** record a suggested payment → it leaves the list and
+  Activity logs it → undo it → it returns. Confirmed as an end user.
+
+## Out of scope (future)
+
+Partial/custom payment amounts, a "mark all paid" bulk action, editing a recorded
+payment (delete + re-add instead), and multi-currency.

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -41,5 +41,9 @@
   "owes": "owes",
   "settled": "settled",
   "pays": "pays",
-  "Everyone is settled up": "Everyone is settled up — no transfers needed"
+  "Everyone is settled up": "Everyone is settled up — no transfers needed",
+  "No groups yet": "No groups yet — create your first one",
+  "Mark paid": "Mark paid",
+  "Recorded payments": "Recorded payments",
+  "Undo": "Undo"
 }

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -41,5 +41,9 @@
   "owes": "a pagar",
   "settled": "quitado",
   "pays": "paga a",
-  "Everyone is settled up": "Tudo certo — nenhuma transferência necessária"
+  "Everyone is settled up": "Tudo certo — nenhuma transferência necessária",
+  "No groups yet": "Nenhum grupo ainda — crie o primeiro",
+  "Mark paid": "Marcar pago",
+  "Recorded payments": "Pagamentos registrados",
+  "Undo": "Desfazer"
 }

--- a/frontend/src/pages/Group/Activity.tsx
+++ b/frontend/src/pages/Group/Activity.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Users, Receipt, Trash2, Pencil, Plus, History } from 'lucide-react';
+import { Users, Receipt, Trash2, Pencil, Plus, History, ArrowLeftRight } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 import { useGroupContext } from '../../context/GroupContext';
@@ -26,6 +26,10 @@ export function GroupActivity() {
 			case ACTIVITY_TYPES.TRANSACTION_UPDATED:
 				return { Icon: Pencil, tone: 'bg-accent text-accent-foreground' };
 			case ACTIVITY_TYPES.TRANSACTION_DELETED:
+				return { Icon: Trash2, tone: 'bg-destructive/15 text-destructive' };
+			case ACTIVITY_TYPES.TRANSFER_RECORDED:
+				return { Icon: ArrowLeftRight, tone: 'bg-primary/15 text-primary' };
+			case ACTIVITY_TYPES.TRANSFER_REMOVED:
 				return { Icon: Trash2, tone: 'bg-destructive/15 text-destructive' };
 			default:
 				return { Icon: Receipt, tone: 'bg-muted text-muted-foreground' };

--- a/frontend/src/pages/Group/ListTransactions.tsx
+++ b/frontend/src/pages/Group/ListTransactions.tsx
@@ -58,7 +58,9 @@ export function GroupListTransactions() {
 		);
 	}
 
-	const hasTransactions = Boolean(group.transactions?.length);
+	// Settle-up transfers live on the Settle up page; the expenses list shows expenses only.
+	const expenses = (group.transactions ?? []).filter((tx) => tx.type !== 'transfer');
+	const hasTransactions = expenses.length > 0;
 
 	return (
 		<Card>
@@ -83,7 +85,7 @@ export function GroupListTransactions() {
 								<TableHead className="text-right">{t('Actions')}</TableHead>
 							</TableRow>
 						</TableHeader>
-						<TableBody>{group.transactions?.map(renderTransaction)}</TableBody>
+						<TableBody>{expenses.map(renderTransaction)}</TableBody>
 					</Table>
 				) : (
 					<div className="flex flex-col items-center gap-4 py-12 text-center">

--- a/frontend/src/pages/Group/Settlement.tsx
+++ b/frontend/src/pages/Group/Settlement.tsx
@@ -1,19 +1,50 @@
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, ArrowLeftRight } from 'lucide-react';
+import { ArrowRight, ArrowLeftRight, Check, Undo2 } from 'lucide-react';
+import ObjectId from 'bson-objectid';
 
 import { useGroupContext } from '../../context/GroupContext';
-import { computeSettlement } from '../../utils/settlement';
+import { computeSettlement, type Transfer } from '../../utils/settlement';
+import { trackTransferRecorded, trackTransferRemoved } from '../../utils/activity-tracker';
 import { Avatar } from '../../components/Avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import type { Transaction } from '../../types';
 
 const SETTLED_EPS = 0.005;
 
 export function GroupSettlement() {
 	const { t } = useTranslation();
-	const { data: group } = useGroupContext();
+	const { data: group, updateGroup } = useGroupContext();
 	const { netBalances, transfers, bankerId } = computeSettlement(group);
+
+	const nameOf = (id: string) => group.members?.find((m) => m.id === id)?.name ?? id;
+	const recorded = (group.transactions ?? []).filter((tx) => tx.type === 'transfer');
+
+	function markPaid(transfer: Transfer) {
+		const txn: Transaction = {
+			id: String(new ObjectId()),
+			type: 'transfer',
+			date: new Date(),
+			createdAt: new Date(),
+			description: 'Settle up',
+			total: transfer.amount,
+			paidBy: { [transfer.fromId]: transfer.amount },
+			paidFor: { [transfer.toId]: transfer.amount },
+		};
+		const updated = trackTransferRecorded(group, transfer.fromName, transfer.toName, transfer.amount);
+		updated.transactions = [...(updated.transactions ?? []), txn];
+		updateGroup(updated);
+	}
+
+	function undoTransfer(txn: Transaction) {
+		const fromId = Object.keys(txn.paidBy)[0] ?? '';
+		const toId = Object.keys(txn.paidFor)[0] ?? '';
+		const updated = trackTransferRemoved(group, nameOf(fromId), nameOf(toId), txn.total);
+		updated.transactions = (updated.transactions ?? []).filter((t) => t.id !== txn.id);
+		updateGroup(updated);
+	}
 
 	if (!group.members || group.members.length === 0) {
 		return (
@@ -24,76 +55,122 @@ export function GroupSettlement() {
 	}
 
 	return (
-		<div className="grid gap-6 md:grid-cols-2">
-			<Card>
-				<CardHeader>
-					<CardTitle>{t('Balances')}</CardTitle>
-				</CardHeader>
-				<CardContent className="space-y-1">
-					{netBalances.map((b) => {
-						const settled = Math.abs(b.balance) < SETTLED_EPS;
-						const positive = b.balance > 0;
-						return (
-							<div
-								key={b.memberId}
-								className="border-border/60 flex items-center gap-3 border-b border-dashed py-2 last:border-0"
-							>
-								<Avatar name={b.name} className="size-8 text-xs" />
-								<span className="flex-1 truncate text-sm font-medium">
-									{b.name}
-									{b.memberId === bankerId && (
-										<Badge variant="muted" className="ml-2 align-middle">
-											{t('Banker')}
-										</Badge>
-									)}
-								</span>
-								<span
-									className={cn(
-										'tnum text-sm font-semibold',
-										settled ? 'text-muted-foreground' : positive ? 'text-primary' : 'text-foreground',
-									)}
+		<div className="space-y-6">
+			<div className="grid gap-6 md:grid-cols-2">
+				<Card>
+					<CardHeader>
+						<CardTitle>{t('Balances')}</CardTitle>
+					</CardHeader>
+					<CardContent className="space-y-1">
+						{netBalances.map((b) => {
+							const settled = Math.abs(b.balance) < SETTLED_EPS;
+							const positive = b.balance > 0;
+							return (
+								<div
+									key={b.memberId}
+									className="border-border/60 flex items-center gap-3 border-b border-dashed py-2 last:border-0"
 								>
-									{settled ? t('settled') : `$${Math.abs(b.balance)}`}
-								</span>
-								{!settled && (
-									<Badge variant={positive ? 'default' : 'secondary'}>{positive ? t('gets back') : t('owes')}</Badge>
-								)}
-							</div>
-						);
-					})}
-				</CardContent>
-			</Card>
+									<Avatar name={b.name} className="size-8 text-xs" />
+									<span className="flex-1 truncate text-sm font-medium">
+										{b.name}
+										{b.memberId === bankerId && (
+											<Badge variant="muted" className="ml-2 align-middle">
+												{t('Banker')}
+											</Badge>
+										)}
+									</span>
+									<span
+										className={cn(
+											'tnum text-sm font-semibold',
+											settled ? 'text-muted-foreground' : positive ? 'text-primary' : 'text-foreground',
+										)}
+									>
+										{settled ? t('settled') : `$${Math.abs(b.balance)}`}
+									</span>
+									{!settled && (
+										<Badge variant={positive ? 'default' : 'secondary'}>{positive ? t('gets back') : t('owes')}</Badge>
+									)}
+								</div>
+							);
+						})}
+					</CardContent>
+				</Card>
 
-			<Card>
-				<CardHeader>
-					<CardTitle>{t('Transfers')}</CardTitle>
-				</CardHeader>
-				<CardContent>
-					{transfers.length === 0 ? (
-						<div className="flex flex-col items-center gap-3 py-10 text-center">
-							<span className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-full">
-								<ArrowLeftRight className="size-7" />
-							</span>
-							<p className="text-muted-foreground">{t('Everyone is settled up')}</p>
-						</div>
-					) : (
+				<Card>
+					<CardHeader>
+						<CardTitle>{t('Transfers')}</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{transfers.length === 0 ? (
+							<div className="flex flex-col items-center gap-3 py-10 text-center">
+								<span className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-full">
+									<ArrowLeftRight className="size-7" />
+								</span>
+								<p className="text-muted-foreground">{t('Everyone is settled up')}</p>
+							</div>
+						) : (
+							<ul className="space-y-2">
+								{transfers.map((tr, i) => (
+									<li
+										key={`${tr.fromId}-${tr.toId}-${i}`}
+										className="border-border/60 flex items-center gap-2 rounded-lg border px-3 py-2"
+									>
+										<span className="truncate text-sm font-semibold">{tr.fromName}</span>
+										<ArrowRight className="text-muted-foreground size-4 shrink-0" />
+										<span className="truncate text-sm font-semibold">{tr.toName}</span>
+										<span className="tnum text-primary ml-auto font-semibold">${tr.amount}</span>
+										<Button
+											type="button"
+											size="sm"
+											variant="outline"
+											className="ml-1 shrink-0"
+											onClick={() => markPaid(tr)}
+										>
+											<Check /> {t('Mark paid')}
+										</Button>
+									</li>
+								))}
+							</ul>
+						)}
+					</CardContent>
+				</Card>
+			</div>
+
+			{recorded.length > 0 && (
+				<Card>
+					<CardHeader>
+						<CardTitle>{t('Recorded payments')}</CardTitle>
+					</CardHeader>
+					<CardContent>
 						<ul className="space-y-2">
-							{transfers.map((tr, i) => (
-								<li
-									key={`${tr.fromId}-${tr.toId}-${i}`}
-									className="border-border/60 flex items-center gap-2 rounded-lg border px-3 py-2.5"
-								>
-									<span className="truncate text-sm font-semibold">{tr.fromName}</span>
-									<span className="text-muted-foreground hidden text-xs sm:inline">{t('pays')}</span>
-									<ArrowRight className="text-muted-foreground size-4 shrink-0" />
-									<span className="truncate text-sm font-semibold">{tr.toName}</span>
-									<span className="tnum text-primary ml-auto font-semibold">${tr.amount}</span>
-								</li>
-							))}
+							{recorded.map((txn) => {
+								const fromId = Object.keys(txn.paidBy)[0] ?? '';
+								const toId = Object.keys(txn.paidFor)[0] ?? '';
+								return (
+									<li key={txn.id} className="border-border/60 flex items-center gap-2 rounded-lg border px-3 py-2">
+										<span className="truncate text-sm font-medium">{nameOf(fromId)}</span>
+										<ArrowRight className="text-muted-foreground size-4 shrink-0" />
+										<span className="truncate text-sm font-medium">{nameOf(toId)}</span>
+										<span className="tnum ml-auto font-semibold">${txn.total}</span>
+										<span className="text-muted-foreground hidden text-xs sm:inline">
+											{txn.createdAt ? new Date(txn.createdAt).toLocaleDateString() : ''}
+										</span>
+										<Button
+											type="button"
+											size="sm"
+											variant="ghost"
+											className="text-muted-foreground hover:text-destructive shrink-0"
+											onClick={() => undoTransfer(txn)}
+										>
+											<Undo2 /> {t('Undo')}
+										</Button>
+									</li>
+								);
+							})}
 						</ul>
-					)}
-				</CardContent>
-			</Card>
+					</CardContent>
+				</Card>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import ObjectId from 'bson-objectid';
-import { Plus, Loader2 } from 'lucide-react';
+import { Plus, Loader2, Users } from 'lucide-react';
 
 import CardContainer from '../components/CardContainer';
 import CardGroup from '../components/CardGroup';
@@ -39,21 +39,32 @@ function HomePage() {
 			</section>
 
 			<section>
-				<div className="mb-6 flex flex-col gap-1">
-					<h2 className="font-serif text-2xl font-semibold tracking-tight">{t('GenGroupTitle')}</h2>
-					<p className="text-muted-foreground text-sm">{t('GenGroupSubTitle')}</p>
-				</div>
-
 				{loading ? (
 					<div className="text-muted-foreground flex items-center justify-center gap-2 py-16">
 						<Loader2 className="size-5 animate-spin" /> {t('Loading')}
 					</div>
+				) : groupList.length === 0 ? (
+					<div className="border-border bg-card/50 flex flex-col items-center gap-3 rounded-2xl border border-dashed p-12 text-center">
+						<span className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-full">
+							<Users className="size-7" />
+						</span>
+						<p className="text-muted-foreground">{t('No groups yet')}</p>
+						<Button onClick={createGroup}>
+							<Plus /> {t('createGroup')}
+						</Button>
+					</div>
 				) : (
-					<CardContainer>
-						{groupList.map((groupItem) => (
-							<CardGroup key={groupItem.id} group={groupItem} />
-						))}
-					</CardContainer>
+					<>
+						<div className="mb-6 flex flex-col gap-1">
+							<h2 className="font-serif text-2xl font-semibold tracking-tight">{t('GenGroupTitle')}</h2>
+							<p className="text-muted-foreground text-sm">{t('GenGroupSubTitle')}</p>
+						</div>
+						<CardContainer>
+							{groupList.map((groupItem) => (
+								<CardGroup key={groupItem.id} group={groupItem} />
+							))}
+						</CardContainer>
+					</>
 				)}
 			</section>
 		</div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,14 +15,22 @@ export interface Member {
 	prepaid: number;
 }
 
+/**
+ * 'expense' = consumption (the full split form). 'transfer' = money moved between
+ * members (a settle-up, or prepaid into the pot) — same shape, simpler entry.
+ */
+export type TransactionType = 'expense' | 'transfer';
+
 export interface Transaction {
 	id: string;
+	/** Defaults to 'expense' when absent. */
+	type?: TransactionType;
 	date: string | Date;
 	description: string;
 	total: number;
-	/** Who actually paid, member id -> amount. */
+	/** Money in (credit). For a transfer this is the sender, member id -> amount. */
 	paidBy: AmountMap;
-	/** Who should be charged / consumed, member id -> amount. */
+	/** Money out (debit). For a transfer this is the recipient, member id -> amount. */
 	paidFor: AmountMap;
 	/** Member ids whose amount the user typed manually (exempt from auto-split). */
 	manuallyChanged?: Record<string, boolean>;

--- a/frontend/src/utils/activity-tracker.test.ts
+++ b/frontend/src/utils/activity-tracker.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+
+import { ACTIVITY_TYPES, trackTransferRecorded, trackTransferRemoved } from './activity-tracker';
+import type { Group } from '../types';
+
+const group: Group = { config: {} };
+
+describe('transfer activity helpers', () => {
+	it('records a transfer with payer, payee and amount in the description', () => {
+		const updated = trackTransferRecorded(group, 'Bob', 'Carol', 40);
+		const entry = updated.activities?.[0];
+		expect(entry?.type).toBe(ACTIVITY_TYPES.TRANSFER_RECORDED);
+		expect(entry?.description).toContain('Bob');
+		expect(entry?.description).toContain('Carol');
+		expect(entry?.description).toContain('40');
+	});
+
+	it('records a transfer removal', () => {
+		const updated = trackTransferRemoved(group, 'Bob', 'Carol', 40);
+		expect(updated.activities?.[0]?.type).toBe(ACTIVITY_TYPES.TRANSFER_REMOVED);
+	});
+});

--- a/frontend/src/utils/activity-tracker.ts
+++ b/frontend/src/utils/activity-tracker.ts
@@ -16,6 +16,10 @@ export const ACTIVITY_TYPES = {
 	TRANSACTION_CREATED: 'transaction_created',
 	TRANSACTION_UPDATED: 'transaction_updated',
 	TRANSACTION_DELETED: 'transaction_deleted',
+
+	// Settle-up transfer activities
+	TRANSFER_RECORDED: 'transfer_recorded',
+	TRANSFER_REMOVED: 'transfer_removed',
 } as const;
 
 export type ActivityType = (typeof ACTIVITY_TYPES)[keyof typeof ACTIVITY_TYPES];
@@ -243,4 +247,26 @@ export function trackMemberChanges(group: Group, oldMembers: Member[] = [], newM
 	}
 
 	return updatedGroup;
+}
+
+/**
+ * Track a recorded settle-up transfer (one member paying another back).
+ */
+export function trackTransferRecorded(group: Group, fromName: string, toName: string, amount: number): Group {
+	const activity = createActivity(ACTIVITY_TYPES.TRANSFER_RECORDED, {
+		description: `${fromName} paid ${toName} $${amount}`,
+		details: { fromName, toName, amount },
+	});
+	return addActivityToGroup(group, activity);
+}
+
+/**
+ * Track the removal (undo) of a settle-up transfer.
+ */
+export function trackTransferRemoved(group: Group, fromName: string, toName: string, amount: number): Group {
+	const activity = createActivity(ACTIVITY_TYPES.TRANSFER_REMOVED, {
+		description: `Removed payment: ${fromName} → ${toName} $${amount}`,
+		details: { fromName, toName, amount },
+	});
+	return addActivityToGroup(group, activity);
 }

--- a/frontend/src/utils/settlement.test.ts
+++ b/frontend/src/utils/settlement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import type { Group } from '../types';
+import type { Group, Transaction } from '../types';
 import { computeBalances, computeSettlement, type Transfer } from './settlement';
 
 function netTransfer(transfers: Transfer[], memberId: string): number {
@@ -176,5 +176,54 @@ describe('computeSettlement', () => {
 		};
 		const { transfers } = computeSettlement(g);
 		expect(transfers.length).toBeLessThanOrEqual(9);
+	});
+});
+
+describe('settle-up transfers (stored as transactions)', () => {
+	// A transfer: sender on paidBy (credit), recipient on paidFor (debit).
+	const transfer = (id: string, from: string, to: string, amount: number): Transaction => ({
+		id,
+		type: 'transfer',
+		date: '2026-06-15',
+		description: 'Settle up',
+		total: amount,
+		paidBy: { [from]: amount },
+		paidFor: { [to]: amount },
+	});
+
+	const singlePayer: Group = {
+		config: { bankerId: 'a' },
+		members: [
+			{ id: 'a', name: 'A', prepaid: 0 },
+			{ id: 'b', name: 'B', prepaid: 0 },
+		],
+		transactions: [
+			{ id: 't1', date: '2026-01-01', description: 'x', total: 100, paidBy: { a: 100 }, paidFor: { a: 50, b: 50 } },
+		],
+	};
+
+	it('folds a transfer into balances: payer up, payee down', () => {
+		const g: Group = { ...singlePayer, transactions: [...singlePayer.transactions!, transfer('p1', 'b', 'a', 50)] };
+		const byId = Object.fromEntries(computeBalances(g).map((b) => [b.memberId, b.balance]));
+		expect(byId).toEqual({ a: 0, b: 0 });
+	});
+
+	it('settles everyone once the suggested transfers are recorded as transfers', () => {
+		const withTransfers: Group = {
+			...beachTrip,
+			transactions: [
+				...beachTrip.transactions!,
+				transfer('p1', 'bob', 'carol', 40),
+				transfer('p2', 'alice', 'carol', 90),
+			],
+		};
+		expect(computeSettlement(withTransfers).transfers).toEqual([]);
+	});
+
+	it('a partial transfer reduces but does not clear the debt', () => {
+		const g: Group = { ...singlePayer, transactions: [...singlePayer.transactions!, transfer('p1', 'b', 'a', 20)] };
+		expect(computeSettlement(g).transfers).toEqual([
+			{ fromId: 'b', fromName: 'B', toId: 'a', toName: 'A', amount: 30 },
+		]);
 	});
 });

--- a/frontend/src/utils/settlement.ts
+++ b/frontend/src/utils/settlement.ts
@@ -39,6 +39,9 @@ export function computeBalances(group: Group): MemberBalance[] {
 	const members = group.members ?? [];
 	const transactions = group.transactions ?? [];
 
+	// Both expenses and transfers are transactions: paidBy is money in (credit),
+	// paidFor is money out (debit). A settle-up transfer therefore folds in for free
+	// (the payer is paidBy, the recipient is paidFor).
 	return members.map((member) => {
 		let paidBy = 0;
 		let paidFor = 0;

--- a/frontend/src/utils/use-api.ts
+++ b/frontend/src/utils/use-api.ts
@@ -1,24 +1,10 @@
 import { useEffect, useState } from 'react';
 import localforage from 'localforage';
-import ObjectId from 'bson-objectid';
 
 import type { Group, GroupListItem } from '../types';
 
 const groupListStore = localforage.createInstance({ name: 'groupList' });
 const groupStore = localforage.createInstance({ name: 'group' });
-
-function generateId(): string {
-	return new ObjectId().toHexString();
-}
-
-async function loadSampleData(): Promise<void> {
-	if (await groupListStore.getItem('groups')) return;
-	await groupListStore.setItem<GroupListItem[]>('groups', [
-		{ id: generateId(), name: 'Grupo Teste' },
-		{ id: generateId(), name: 'Grupo Teste' },
-		{ id: generateId(), name: 'Grupo Teste' },
-	]);
-}
 
 export function useApiListGroups(): { loading: boolean; groupList: GroupListItem[] } {
 	const [loading, setLoading] = useState(false);
@@ -27,7 +13,6 @@ export function useApiListGroups(): { loading: boolean; groupList: GroupListItem
 	useEffect(() => {
 		setLoading(true);
 		const fetchData = async () => {
-			await loadSampleData();
 			const groups = (await groupListStore.getItem<GroupListItem[]>('groups')) || [];
 			setGroupList(groups);
 			setLoading(false);


### PR DESCRIPTION
## Summary

Lets users record settle-up transfers as paid so the suggested-transfers list reflects what's actually been settled — building on the unification insight that **a transfer is just a transaction**.

- A settle-up is stored as a `Transaction` of `type: 'transfer'` (sender → `paidBy`, recipient → `paidFor`), so it folds into balances with **no separate payments array and no new settlement code**.
- **Settle up** page: a **Mark paid** button per suggested transfer, and a **Recorded payments** list with **Undo**. Both log to Activity (`TRANSFER_RECORDED` / `TRANSFER_REMOVED`).
- Transfers are filtered out of the Transactions (expenses) list.

## Also in this PR

- **refactor(home):** stop seeding three fake "Grupo Teste" groups; show a real empty state (icon + create-group CTA) when no groups exist. "Load sample data" still lives inside a group.
- **docs:** refresh `ARCHITECTURE.md` to the current stack and record the project rules — expenses vs member-to-member transfers (prepaid + settle-up are one concept), the lake-house/organizer framing, and the no-PII per-event/per-member UUID identity model. Update `TEST.md` and add the design spec.

## Testing

- Unit tests (TDD): transfer transactions fold into balances; recording the suggested transfers settles everyone; partial transfer; transfer activity helpers (19 tests total).
- Live Chrome MCP QA: mark paid → settled + recorded + logged; undo → reverts; home empty state on a fresh profile.

---

Design spec: `docs/superpowers/specs/2026-06-14-mark-transfers-paid-design.md`
