### PR TITLE
i18n(pt): label 'Paid for' as 'Gasto por'

### DIFF
--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -27,7 +27,7 @@
   "Add Transaction": "Adicionar Transação",
   "Want to see some example transactions?": "Quer ver algumas transações de exemplo?",
   "Paid by": "Pago por",
-  "Paid for": "Pago para",
+  "Paid for": "Gasto por",
   "Remaining": "Restante",
   "Content not found": "Conteúdo não encontrado",
   "Actions": "Ações",


### PR DESCRIPTION
Better BR-PT wording for the expense form: the consumer side reads **Gasto por** (spent by) instead of *Pago para*; **Paid by** stays *Pago por*.