### PR TITLE
i18n(en): label 'Paid for' as 'Consumed by'

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -27,7 +27,7 @@
   "Add Transaction": "Add Transaction",
   "Want to see some example transactions?": "Want to see some example transactions?",
   "Paid by": "Paid by",
-  "Paid for": "Paid for",
+  "Paid for": "Consumed by",
   "Remaining": "Remaining",
   "Content not found": "Content not found",
   "Actions": "Actions",


### PR DESCRIPTION
Clearer English for the expense's consumer side (who used/ate it), pairing with **Paid by** and matching the PT *Gasto por*. Only the English label changes; the i18n key stays `Paid for`.