### PR TITLE
feat(settlement): top-up & top-holder (replaces prepaid/banker)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,10 +21,10 @@ There are exactly **two kinds of money movement**, and keeping them distinct is 
 1. **Expenses** (`transactions`) — *consumption*. Each records, separately, *who actually paid* (`paidBy`) and *who should be charged* (`paidFor`); these need not match (the person with cash pays the street-food vendor, but someone else eats the food). An auto-split helper fills in the rest so nobody does mental arithmetic (§6).
 
 2. **Transfers** — money one member hands another that is **not** an expense, but still moves their balances. This single primitive covers two product features that are conceptually the same thing:
-   - **Prepaid** — money members put in up front, typically to one organizer. Example: ten friends rent a lake-house; one person makes the booking and pays, so everyone wires **them** first. The organizer waits until everyone has paid in before committing, and isn't left out of pocket if some people flake. That collected money sits in the organizer's balance, ready to be drawn down by the lake-house expense.
-   - **Settle-up** — a debtor paying a creditor to clear the balance the app computed (during or at the end of the trip).
+   - **Top-up** *(optional)* — a member adds money to the pot any time (generalises the old "prepaid"). Example: ten friends rent a lake-house; the **top-holder** (organizer) collects everyone's money up front before committing. A top-up credits **only the depositing member**; the holder merely *holds* the pooled cash (no balance effect) and refunds whatever's unused at the end.
+   - **Settle-up** — a debtor paying a creditor to clear the balance the app computed.
 
-   **Rule (project owner):** prepaid and settle-up are the same concept — "A gave B money, counts toward balances, is not an expense." The target model collapses both into one **member-to-member transfer** list (§6). A pleasant consequence: with transfers and expenses both balanced, every member balance sums to zero, so settlement is pure peer-to-peer with no special "banker pot" handling.
+   **Rule (project owner):** top-up and settle-up are both *transfers* — "money that moves between accounts, counts toward balances, isn't an expense" — stored as transactions (§6). A top-up is a self-credit (from = to = the member; the holder is just a note); a settle-up moves between two members. Top-up is optional: a group can pay as-you-go and settle the leftover at the end with no top-ups at all.
 
 ### 1.2 Fewest-transfers settlement
 
@@ -103,7 +103,7 @@ Root scripts: `npm run dev`, `npm run format`, `npm run lint`. Frontend scripts 
 
 **Domain & data layer (`utils/`)**
 - `use-api.ts` — the persistence boundary. localforage stores `groupList` and `group`; hooks `useApiListGroups`, `useApiGetGroup`; `loadDemoData`; `generateId()`. *Single place that touches storage.*
-- `settlement.ts` — **pure** settlement engine: `computeBalances` and `computeSettlement` (balances → banker pot adjustment → greedy min-cash-flow → fewest `transfers` + `netBalances`). Unit-tested.
+- `settlement.ts` — **pure** settlement engine: `computeBalances` (ΣpaidBy − ΣpaidFor), `topupTotal`, and `computeSettlement` (offset the holder by Σtop-ups → greedy min-cash-flow → fewest `transfers`). Unit-tested.
 - `transaction.ts` — `getTransactionError` (form validation), unit-tested.
 - `activity-tracker.ts` — `ACTIVITY_TYPES` + pure functions appending audit entries (capped 100, newest first).
 - `tools.ts` — `jsonParseSafe` / `jsonStringifySafe`.
@@ -124,7 +124,8 @@ SPA, client-side routing only (Vercel rewrites all paths to `index.html`). The s
 | Path | Renders |
 |---|---|
 | `/` | `HomePage` (group list) |
-| `/group/:groupId/config` | `GroupConfig` (name, members, prepaid, banker) |
+| `/group/:groupId/config` | `GroupConfig` (name, members, top-holder) |
+| `/group/:groupId/topup` | `GroupTopUp` (record a top-up) |
 | `/group/:groupId/transactions[/:id\|new]` | transactions list / `GroupTransaction` |
 | `/group/:groupId/settlement` | `GroupSettlement` (balances + transfers) |
 | `/group/:groupId/activity` | `GroupActivity` |
@@ -138,28 +139,26 @@ All state is one **group object** per group id, stored in IndexedDB (typed in `t
 
 ```ts
 Group = {
-  config:   { name?, bankerId? },          // bankerId = member holding the prepaid pot
-  members:  Member[],                       // { id, name, prepaid }
-  transactions: Transaction[],              // { id, type?: 'expense'|'transfer', date, description,
+  config:   { name?, holderId? },          // holderId = member holding the pooled top-up cash
+  members:  Member[],                       // { id, name }   (legacy optional `prepaid`, migrated away)
+  transactions: Transaction[],              // { id, type?: 'expense'|'transfer'|'topup', date, description,
                                             //   total, paidBy:{memberId:amount},
                                             //   paidFor:{memberId:amount}, manuallyChanged }
   activities?: Activity[],                  // audit log (capped 100, newest first)
 }
 ```
 
-**Expenses vs. transfers are both `Transaction`s** (§1.1). An expense (`type` absent / `'expense'`) is consumption entered via the split form. A **transfer** (`type: 'transfer'`) is money between members — a settle-up (or, in future, prepaid) — with the *sender* on `paidBy` (credit) and *recipient* on `paidFor` (debit). Same shape, so it folds into balances for free; entered via the Settle up page, and filtered out of the expenses list.
+**Everything is a `Transaction`** (§1.1). An expense (`type` absent / `'expense'`) is consumption via the split form. A **transfer** (`type: 'transfer'`, a settle-up) moves money between two members — *sender* on `paidBy` (credit), *recipient* on `paidFor` (debit). A **top-up** (`type: 'topup'`) is a self-credit — `paidBy = {member: amount}`, empty `paidFor`. All fold into balances for free; transfers and top-ups are entered on/near the Settle up page and filtered out of the expenses list.
 
 ### Auto-split (`Transaction.tsx`)
 Both `paidBy` and `paidFor` are `memberId → amount` maps. Toggling a member splits the remaining `total − sum(manually-typed)` equally across the others; rounding remainder lands on the current person so the parts reconcile to `total`. Most intricate code in the app.
 
 ### Settlement (`settlement.ts`) — **built & tested**
-- `balance(m) = prepaid(m) + Σ paidBy − Σ paidFor + Σ (transfers given − received)`.
-- **Banker:** prepaid is currently a per-member number whose recipient is the **banker** (`config.bankerId`, default first member). The banker holds the pot, so their *effective* balance is reduced by `Σ prepaid`, making effective balances sum to zero.
-- `computeSettlement` runs a greedy **min-cash-flow** (largest creditor ↔ largest debtor) → fewest `transfers` (≤ n−1) plus `netBalances` (post-banker, sum to zero, match the transfers).
-- **Settle-up** is recorded as a `type: 'transfer'` transaction, so it folds into `computeBalances` for free (sender `paidBy` +, recipient `paidFor` −); recording one shrinks/clears its suggested transfer. Undo deletes the transaction.
-
-### Planned unification (project-owner rule, §1.1)
-Prepaid is still a per-member number routed to the banker (mathematically equal to "everyone transferred their prepaid to the organizer"). The remaining step is to also express **prepaid as transfer transactions** to the organizer, retiring `member.prepaid` and the banker special-case so every balance is just `Σ(paidBy − paidFor)` over transactions. Settle-up already works this way.
+- `balance(m) = Σ paidBy(m) − Σ paidFor(m)` over all transactions. A **top-up** (`type: 'topup'`, `paidBy = {m: amount}`, empty `paidFor`) credits only that member. Positive = owed, negative = owes.
+- **Top-holder:** `config.holderId` (default first member) holds the pooled top-up cash — **no balance effect from holding**. For the transfer computation *only*, their position is offset by `−Σ top-ups` (`topupTotal`), making effective balances sum to zero so refunds route through them.
+- `computeSettlement` runs a greedy **min-cash-flow** → fewest `transfers` (≤ n−1). With no top-ups the offset is zero and it degrades to plain peer-to-peer fewest-transfers.
+- **Settle-up** is a `type: 'transfer'` transaction (sender `paidBy` +, recipient `paidFor` −); recording one shrinks/clears its suggested transfer, undo deletes it.
+- **Display:** the Balances panel shows each member's *raw* balance (the holder is never shown "owing") + "deposited"; the Transfers panel shows the holder doing the refunds.
 
 ---
 
@@ -201,7 +200,7 @@ React UI ──updateGroup(next)──► GroupContext ──► useApiGetGroup
 ## 10. Known Tech Debt & Code Hotspots
 
 - **`Transaction.tsx` auto-split** — complex in-place mutation + rounding; highest-risk hotspot, still untested at the component level (the pure split rules are the candidate to extract + unit-test).
-- **Prepaid still a number** — settle-up is now a transfer transaction, but prepaid remains `member.prepaid` + the banker special-case; express prepaid as transfer transactions too to retire the banker (§6).
+- **`member.prepaid` legacy field** — kept optional only so old groups migrate to top-ups on load (`use-api` `groupStandardize`); unused by new code. Likewise `config.bankerId` → `holderId`.
 - **Inconsistent member ids** — members use `"${index}_${Date.now()}"` while transactions/activities use ObjectId hex. Move members to UUIDs with the identity model.
 - **`activities.userId` unused** — placeholder until the UUID identity model lands.
 - **No component/E2E tests** — only pure-logic unit tests exist.
@@ -214,7 +213,7 @@ Source: project owner. Order indicative.
 
 1. ✅ **TypeScript migration**, dependency upgrades, **shadcn/Tailwind v4 redesign**, **CI** (lint+test+build), **settlement engine**.
 2. ✅ **Mark transfers as paid** — settle-ups recorded as transfer transactions that net down balances; undoable; logged to Activity.
-3. **Finish unifying prepaid** — express prepaid as transfer transactions to the organizer too, removing `member.prepaid` and the banker special-case (§6).
+3. ✅ **Top-up & top-holder** — prepaid generalised to optional top-up transactions; the holder holds the pot and refunds the unused part; the banker special-case is gone.
 4. **Identity & privacy model** — per-event + per-member UUIDs so members contribute independently with no PII (§1.3); member identification in **v2**.
 5. **Backend sync layer** — local-first stays source of truth; reconcile multi-device offline edits (needs the UUID identities + conflict resolution).
 6. **Visual design via Stitch MCP** — generate fresh modern layouts, recorded in `DESIGN.md`.

--- a/TEST.md
+++ b/TEST.md
@@ -33,8 +33,9 @@ npm run build --workspace frontend # tsc type-check + production build
 
 Most tests below use this group:
 
-- **Group:** `Beach Trip`
-- **Members:** `Alice` (prepaid 100), `Bob` (prepaid 0), `Carol` (prepaid 50)
+- **Group:** `Beach Trip`, top-holder `Alice`
+- **Members:** `Alice`, `Bob`, `Carol`
+- **Top-ups:** Alice `100`, Carol `50` (added via Settle up → Top up)
 - **Expense:** `Dinner`, total `120`
 
 ---
@@ -79,14 +80,14 @@ Most tests below use this group:
 2. Change **Group name** to `Beach Trip` → **Save**.
 3. **Expected:** the large group heading updates to `Beach Trip`.
 
-### TC-2.2 — Add members with prepaid amounts
+### TC-2.2 — Add members and pick the top-holder
 
-1. On Config, fill the first member: name `Alice`, prepaid `100`.
-2. Click **member** to add a row; fill `Bob`, prepaid `0`.
-3. Click **member** again; fill `Carol`, prepaid `50`.
-4. Click **Save**.
-5. **Expected:** member count shows `3`; each member shows an initials avatar
-   (e.g. "A", "B", "C") in a colored circle. Values persist after Save.
+1. On Config, fill the first member `Alice`; **+ member** → `Bob`; **+ member** → `Carol`.
+2. Set the **Top-holder** dropdown (defaults to the first member).
+3. Click **Save**.
+4. **Expected:** member count shows `3`; each shows an initials avatar; the
+   holder choice persists. There is no per-member "prepaid" input — money is added
+   later via **Top up** (see §7). Members carry no amounts here.
 
 ### TC-2.3 — Remove a member
 
@@ -213,37 +214,39 @@ Most tests below use this group:
 
 ## 7. Settle up (balances & fewest transfers)
 
-Settlement is derived (not stored). Balances use
-`balance = prepaid + paidBy − paidFor`; the **banker** holds the prepaid pot, so
-the net balances (shown on the page) sum to zero and match the transfers. The
-pure logic is also covered by unit tests: `npm test --workspace frontend`.
+Settlement is derived (suggested transfers are not stored). `balance = ΣpaidBy −
+ΣpaidFor`; a **top-up** credits its member; the **top-holder** holds the pooled
+top-up cash and (for the transfer computation only) is offset by Σtop-ups, so
+refunds route through them. Pure logic is covered by unit tests: `npm test
+--workspace frontend`.
 
-### TC-7.1 — Choose the banker
+### TC-7.1 — Top up a member
 
-1. Open a group → **Config** → set the **Banker** dropdown to a member → **Save**.
-2. **Expected:** the choice persists across reload (defaults to the first member
-   when never set).
+1. Open a group → **Settle up** → **Top up**. Choose a member, enter an amount,
+   optionally a note → **Top up**.
+2. **Expected:** back on Settle up, the member's balance rises by that amount
+   (badge "gets back", "deposited $X"), the top-up appears under **Top-ups**, and
+   Activity logs "{member} topped up $X". Undo removes it.
 
-### TC-7.2 — Balances and transfers (worked example)
+### TC-7.2 — Holder refunds the unused pot (top-ups, no expenses)
 
-1. Use the `Beach Trip` group (Alice 100 / Bob 0 / Carol 50, banker Alice) with
-   the `Dinner` $120 expense (paid by Carol; split 40/40/40). Open **Settle up**.
-2. **Expected balances (net):** Alice owes $90, Bob owes $40, Carol gets back $130.
-3. **Expected transfers:** `Bob → Carol $40` and `Alice → Carol $90` (2 transfers);
-   the net balances sum to zero.
+1. `Beach Trip`, holder Alice. Top up: Alice $100, Carol $50 (Bob none). No expenses.
+2. **Expected:** Alice (Holder) +$100, Bob settled, Carol +$50; transfer
+   `Alice → Carol $50` (Alice holds the $150 pot, refunds Carol, keeps her own).
 
-### TC-7.3 — Prepaid-only refund via the banker
+### TC-7.3 — Out-of-pocket payer is refunded by the holder
 
-1. Same members, banker Alice, but **no transactions**. Open **Settle up**.
-2. **Expected:** Carol gets back $50, Bob settled, Alice (banker) owes $50;
-   transfer `Alice → Carol $50` (Alice returns Carol's prepaid from the pot and
-   keeps her own).
+1. Top up Alice/Bob/Carol $100 each (holder Alice). Add an expense Bob paid out of
+   pocket (e.g. $90 street food, split 30/30/30).
+2. **Expected:** transfers come *from Alice* (the holder) — she refunds Bob his
+   leftover + the $90 he fronted, and Carol her leftover.
 
-### TC-7.4 — Everyone already even
+### TC-7.4 — No top-ups → plain fewest-transfers
 
-1. A group where each member's contributions equal their consumption.
-2. **Expected:** all rows show "settled" and the Transfers panel shows
-   "Everyone is settled up — no transfers needed".
+1. A pay-as-you-go group: an expense paid by one member, split among all, **no
+   top-ups**, no holder needed.
+2. **Expected:** ordinary debtor→creditor transfers (the holder isn't special);
+   when everyone's even, "Everyone is settled up — no transfers needed".
 
 ### TC-7.5 — Mark a transfer as paid
 
@@ -273,13 +276,12 @@ pure logic is also covered by unit tests: `npm test --workspace frontend`.
 
 ## Known issues / notes
 
-- **Silent validation on transaction save (TC-3.6):** if Date, Total, or
-  Description is empty the Save is ignored without any visible message
-  (`Transaction.tsx` logs to console only — there is a `TODO` for UI feedback).
-- **Settlement banker model:** settle-up assumes one **banker** holds the prepaid
-  pot and disburses refunds (so a banker can show as "owes" while having prepaid
-  the most — that's the cash they pay out of the pot, and it matches the transfer
-  lines). Transfer minimization is greedy (near-optimal), not provably minimal.
-- **No favicon:** the initial page load logs one harmless `404` for the favicon.
+- **Settlement holder model:** the **top-holder** holds the pooled top-up cash and
+  refunds it, so when there are top-ups the suggested transfers route through the
+  holder (each other member deals only with the holder; the holder makes several).
+  Transfer minimization is greedy (near-optimal), not provably minimal.
+- **Expenses always have a payer:** an expense paid "from the pot" isn't modelled
+  as a no-payer transaction; record who actually paid (`paidBy`). Pot-funding is
+  implicit via top-ups + the holder refund.
 - **Native date input:** automated tools may need to set the date field
   programmatically; manual testing with the date picker works normally.

--- a/docs/superpowers/specs/2026-06-14-top-up-and-holder-design.md
+++ b/docs/superpowers/specs/2026-06-14-top-up-and-holder-design.md
@@ -1,0 +1,90 @@
+# Top-up & top-holder — design
+
+> Status: draft for review (2026-06-14). Replaces the static `prepaid` number and
+> the "banker" with a **top-up** transaction and a **top-holder**. Builds on the
+> already-shipped model where settle-ups are `type: 'transfer'` transactions.
+
+## Optionality
+
+Top-up is **optional**. The app fully supports the simple flow — pay transactions
+as you go and settle the leftover at the end, with no top-ups at all. Top-up is a
+**special feature** for groups whose organiser needs to collect money up front
+before committing (e.g. booking the lake-house). When no one tops up, settlement
+is plain fewest-transfers among members (see §Settlement).
+
+## Concepts
+
+- **Top-up** — a member adds money to the shared pot, **any time** (generalises
+  "prepaid", which was top-up-at-creation only). It credits **only that member's**
+  balance (`+`), like topping up your own bank account. It is its own transaction
+  kind (`type: 'topup'`): `paidBy = { [member]: amount }`, `paidFor = {}` — money
+  in, no consumption.
+- **Top-holder** — the member who physically holds the pooled top-up cash
+  (`config.holderId`, normally the organiser; defaults to the first member). A
+  **holder, not an owner**: holding the pot does **not** change their own balance.
+
+## Balances
+
+```
+balance(m) = Σ paidBy(m) − Σ paidFor(m)        // over expenses + transfers + top-ups
+```
+
+- Top-up → `+`. Out-of-pocket payment (`paidBy` on an expense, e.g. John's cash
+  street-food) → `+`. Your share of expenses (`paidFor`) → `−`.
+- **positive = you get money back; negative = you owe.** No member is shown
+  "owing the pot" just for being the holder.
+- Per member the balance screen also shows **deposited** (Σ their top-ups) so the
+  holder can see how much each person put in.
+
+## Settlement (holder-hub)
+
+The top-holder holds `Σ top-ups` in cash. For the transfer computation only, the
+holder's position is offset by `−Σ top-ups` (they owe the pot back). This makes
+balances sum to zero, and the existing greedy **min-cash-flow** then routes money
+correctly: members who owe pay the holder, and the holder refunds members who are
+owed (unused top-ups **+** any out-of-pocket they fronted).
+
+- With top-ups present, this naturally makes the **holder the hub** — each other
+  member makes ~one transfer, the holder makes several (the real-life flow:
+  "organiser refunds everyone their unused money").
+- With **no** top-ups (`Σ = 0`, e.g. a plain restaurant bill), the offset is zero,
+  the holder isn't special, and it degrades to ordinary **fewest-transfers** among
+  members. One algorithm covers both.
+
+**Display rule:** the **Balances** panel shows each member's *own* balance (holder
+**not** offset, so never shown "owing the pot") + a "Holder · holds $X" note on the
+holder. The **Transfers** panel shows the actual suggested payments (computed with
+the offset), which is where the holder appears refunding/collecting. The two
+intentionally differ for the holder, because they're distributing pooled money,
+not their own.
+
+## UI changes
+
+- **Config:** remove the per-member **Prepaid** input and the **Banker** dropdown.
+  Add a **Top-holder** dropdown (relabelled `holderId`).
+- **Top-up entry:** a simple screen/dialog (member + amount + optional note of who
+  they handed cash to) that appends a `type: 'topup'` transaction. Reachable from
+  the group (e.g. a "Top up" button on Settle up / Transactions).
+- **Settle up:** balances show "deposited / net"; the holder is badged; transfers
+  and the existing **Mark paid** + **Recorded payments** stay.
+- Top-ups (like transfers) are **filtered out of the expenses list**; they show in
+  Activity (`TOPUP_RECORDED`).
+
+## Data / migration
+
+- Add `'topup'` to `TransactionType`. Add `config.holderId` (replaces `bankerId`).
+- **Remove `member.prepaid`.** Pre-production, so existing groups carrying
+  `prepaid` are migrated on load: for each member with `prepaid > 0`, synthesise a
+  `topup` transaction crediting them (held by the holder), then drop the field.
+
+## Testing
+
+- Unit (TDD): top-up credits only the topper; holder-hub settlement (members ↔
+  holder); no-top-up groups fall back to fewest-transfers; out-of-pocket payer
+  (John) is refunded by the holder; "deposited" totals.
+- Live Chrome MCP QA: add top-ups, see balances + holder, run settle up, mark paid.
+
+## Out of scope
+
+Partial top-up withdrawals, multi-holder, multi-currency, editing a top-up
+(delete + re-add).

--- a/frontend/src/components/GroupPageWrapper.tsx
+++ b/frontend/src/components/GroupPageWrapper.tsx
@@ -11,6 +11,7 @@ import { GroupListTransactions } from '../pages/Group/ListTransactions';
 import { GroupTransaction } from '../pages/Group/Transaction';
 import { GroupActivity } from '../pages/Group/Activity';
 import { GroupSettlement } from '../pages/Group/Settlement';
+import { GroupTopUp } from '../pages/Group/TopUp';
 import { Button } from '@/components/ui/button';
 
 function GroupContent() {
@@ -22,6 +23,7 @@ function GroupContent() {
 		config: section === 'config',
 		transactions: section === 'transactions',
 		settlement: section === 'settlement',
+		topup: section === 'topup',
 		activity: section === 'activity',
 	};
 
@@ -40,6 +42,7 @@ function GroupContent() {
 				{pages.transactions &&
 					(sectionItem ? <GroupTransaction transactionId={sectionItem} /> : <GroupListTransactions />)}
 				{pages.settlement && <GroupSettlement />}
+				{pages.topup && <GroupTopUp />}
 				{pages.activity && <GroupActivity />}
 			</div>
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -45,5 +45,14 @@
   "No groups yet": "No groups yet — create your first one",
   "Mark paid": "Mark paid",
   "Recorded payments": "Recorded payments",
-  "Undo": "Undo"
+  "Undo": "Undo",
+  "Top up": "Top up",
+  "Top-holder": "Top-holder",
+  "HolderHint": "Holds the pooled top-up cash and refunds what's unused at the end",
+  "Holder": "Holder",
+  "Deposited": "deposited",
+  "Top-ups": "Top-ups",
+  "Amount": "Amount",
+  "Member": "Member",
+  "Note": "Note"
 }

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -45,5 +45,14 @@
   "No groups yet": "Nenhum grupo ainda — crie o primeiro",
   "Mark paid": "Marcar pago",
   "Recorded payments": "Pagamentos registrados",
-  "Undo": "Desfazer"
+  "Undo": "Desfazer",
+  "Top up": "Adicionar saldo",
+  "Top-holder": "Responsável pelo caixa",
+  "HolderHint": "Guarda o dinheiro do caixa e devolve o que sobrar no final",
+  "Holder": "Caixa",
+  "Deposited": "depositado",
+  "Top-ups": "Adições de saldo",
+  "Amount": "Valor",
+  "Member": "Membro",
+  "Note": "Nota"
 }

--- a/frontend/src/pages/Group/Activity.tsx
+++ b/frontend/src/pages/Group/Activity.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Users, Receipt, Trash2, Pencil, Plus, History, ArrowLeftRight } from 'lucide-react';
+import { Users, Receipt, Trash2, Pencil, Plus, History, ArrowLeftRight, PiggyBank } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 import { useGroupContext } from '../../context/GroupContext';
@@ -30,6 +30,10 @@ export function GroupActivity() {
 			case ACTIVITY_TYPES.TRANSFER_RECORDED:
 				return { Icon: ArrowLeftRight, tone: 'bg-primary/15 text-primary' };
 			case ACTIVITY_TYPES.TRANSFER_REMOVED:
+				return { Icon: Trash2, tone: 'bg-destructive/15 text-destructive' };
+			case ACTIVITY_TYPES.TOPUP_RECORDED:
+				return { Icon: PiggyBank, tone: 'bg-primary/15 text-primary' };
+			case ACTIVITY_TYPES.TOPUP_REMOVED:
 				return { Icon: Trash2, tone: 'bg-destructive/15 text-destructive' };
 			default:
 				return { Icon: Receipt, tone: 'bg-muted text-muted-foreground' };

--- a/frontend/src/pages/Group/Config.tsx
+++ b/frontend/src/pages/Group/Config.tsx
@@ -13,32 +13,28 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export function GroupConfig() {
-	const memberBase: Member = { id: `0_${Date.now()}`, name: '', prepaid: 0 };
+	const memberBase: Member = { id: `0_${Date.now()}`, name: '' };
 
 	const { data: group, updateGroup } = useGroupContext();
 	const [formFields, setFormFields] = useState<{ name: string }>({ name: '' });
 	const [members, setMembers] = useState<Member[]>([{ ...memberBase }]);
-	const [bankerId, setBankerId] = useState<string>('');
+	const [holderId, setHolderId] = useState<string>('');
 	const { t } = useTranslation();
 
 	useEffect(() => {
 		setFormFields({ name: group.config?.name || '---' });
 		if (group.members) setMembers(group.members);
-		setBankerId(group.config?.bankerId || group.members?.[0]?.id || '');
+		setHolderId(group.config?.holderId || group.members?.[0]?.id || '');
 	}, [group]);
 
-	const memberName = 'memberName';
-	const memberPrepaid = 'memberPrepaid';
 	function addMember() {
 		setMembers([...members, { ...memberBase, id: `${members.length}_${Date.now()}` }]);
 	}
 	function removeMember(member: Member) {
 		setMembers(members.filter((m) => m.id !== member.id));
 	}
-	function handleMemberFields(member: Member, event: ChangeEvent<HTMLInputElement>) {
-		const { name, value } = event.target;
-		if (name == memberName) member.name = value;
-		else if (name == memberPrepaid) member.prepaid = Number(value);
+	function handleMemberName(member: Member, event: ChangeEvent<HTMLInputElement>) {
+		member.name = event.target.value;
 		setMembers([...members]);
 	}
 
@@ -51,18 +47,12 @@ export function GroupConfig() {
 
 		let updatedGroup = { ...group };
 
-		// Track group name change
 		const oldGroupName = group.config?.name || '';
-		const newGroupName = formFields.name;
-		updatedGroup = trackGroupNameChange(updatedGroup, oldGroupName, newGroupName);
+		updatedGroup = trackGroupNameChange(updatedGroup, oldGroupName, formFields.name);
+		updatedGroup = trackMemberChanges(updatedGroup, group.members || [], members);
 
-		// Track member changes
-		const oldMembers = group.members || [];
-		updatedGroup = trackMemberChanges(updatedGroup, oldMembers, members);
-
-		// Apply the changes
-		const validBanker = members.some((m) => m.id === bankerId) ? bankerId : members[0]?.id;
-		updatedGroup.config = { ...updatedGroup.config, name: formFields.name, bankerId: validBanker };
+		const validHolder = members.some((m) => m.id === holderId) ? holderId : members[0]?.id;
+		updatedGroup.config = { ...updatedGroup.config, name: formFields.name, holderId: validHolder };
 		updatedGroup.members = members;
 
 		updateGroup(updatedGroup);
@@ -89,13 +79,13 @@ export function GroupConfig() {
 							onChange={handleFieldChange}
 						/>
 
-						<Label htmlFor="group-banker" className="mt-4 mb-2">
-							{t('Banker')}
+						<Label htmlFor="group-holder" className="mt-4 mb-2">
+							{t('Top-holder')}
 						</Label>
 						<select
-							id="group-banker"
-							value={bankerId}
-							onChange={(e) => setBankerId(e.target.value)}
+							id="group-holder"
+							value={holderId}
+							onChange={(e) => setHolderId(e.target.value)}
 							className="border-input bg-background focus-visible:border-ring focus-visible:ring-ring/50 flex h-10 w-full rounded-md border px-3 py-2 text-base shadow-xs outline-none focus-visible:ring-[3px]"
 						>
 							{members.map((member) => (
@@ -104,7 +94,7 @@ export function GroupConfig() {
 								</option>
 							))}
 						</select>
-						<p className="text-muted-foreground mt-1.5 text-xs">{t('BankerHint')}</p>
+						<p className="text-muted-foreground mt-1.5 text-xs">{t('HolderHint')}</p>
 					</CardContent>
 				</Card>
 
@@ -123,25 +113,8 @@ export function GroupConfig() {
 										type="text"
 										placeholder={t('TypeHere')}
 										value={member.name}
-										name={memberName}
-										onChange={(event) => handleMemberFields(member, event)}
+										onChange={(event) => handleMemberName(member, event)}
 									/>
-								</div>
-								<div className="w-28">
-									<Label className="text-muted-foreground mb-1.5 text-xs">{t('PrepaidAmount')}</Label>
-									<div className="relative">
-										<span className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm">
-											$
-										</span>
-										<Input
-											type="number"
-											className="tnum pl-7"
-											placeholder="0"
-											value={member.prepaid}
-											name={memberPrepaid}
-											onChange={(event) => handleMemberFields(member, event)}
-										/>
-									</div>
 								</div>
 								<Button
 									type="button"

--- a/frontend/src/pages/Group/Settlement.tsx
+++ b/frontend/src/pages/Group/Settlement.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, ArrowLeftRight, Check, Undo2 } from 'lucide-react';
+import { Link, useParams } from 'react-router-dom';
+import { ArrowRight, ArrowLeftRight, Check, Undo2, PiggyBank } from 'lucide-react';
 import ObjectId from 'bson-objectid';
 
 import { useGroupContext } from '../../context/GroupContext';
 import { computeSettlement, type Transfer } from '../../utils/settlement';
-import { trackTransferRecorded, trackTransferRemoved } from '../../utils/activity-tracker';
+import { trackTransferRecorded, trackTransferRemoved, trackTopupRemoved } from '../../utils/activity-tracker';
 import { Avatar } from '../../components/Avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -16,11 +17,19 @@ const SETTLED_EPS = 0.005;
 
 export function GroupSettlement() {
 	const { t } = useTranslation();
+	const { groupId } = useParams();
 	const { data: group, updateGroup } = useGroupContext();
-	const { netBalances, transfers, bankerId } = computeSettlement(group);
+	const { balances, transfers, holderId } = computeSettlement(group);
 
 	const nameOf = (id: string) => group.members?.find((m) => m.id === id)?.name ?? id;
-	const recorded = (group.transactions ?? []).filter((tx) => tx.type === 'transfer');
+	const txns = group.transactions ?? [];
+	const recordedTransfers = txns.filter((tx) => tx.type === 'transfer');
+	const recordedTopups = txns.filter((tx) => tx.type === 'topup');
+
+	const deposited: Record<string, number> = {};
+	for (const tx of recordedTopups) {
+		for (const [id, amount] of Object.entries(tx.paidBy)) deposited[id] = (deposited[id] ?? 0) + amount;
+	}
 
 	function markPaid(transfer: Transfer) {
 		const txn: Transaction = {
@@ -38,11 +47,13 @@ export function GroupSettlement() {
 		updateGroup(updated);
 	}
 
-	function undoTransfer(txn: Transaction) {
+	function removeTransaction(txn: Transaction) {
 		const fromId = Object.keys(txn.paidBy)[0] ?? '';
-		const toId = Object.keys(txn.paidFor)[0] ?? '';
-		const updated = trackTransferRemoved(group, nameOf(fromId), nameOf(toId), txn.total);
-		updated.transactions = (updated.transactions ?? []).filter((t) => t.id !== txn.id);
+		const updated =
+			txn.type === 'topup'
+				? trackTopupRemoved(group, nameOf(fromId), txn.total)
+				: trackTransferRemoved(group, nameOf(fromId), nameOf(Object.keys(txn.paidFor)[0] ?? ''), txn.total);
+		updated.transactions = (updated.transactions ?? []).filter((tx) => tx.id !== txn.id);
 		updateGroup(updated);
 	}
 
@@ -56,13 +67,21 @@ export function GroupSettlement() {
 
 	return (
 		<div className="space-y-6">
+			<div className="flex justify-end">
+				<Button asChild variant="outline" size="sm">
+					<Link to={`/group/${groupId}/topup`}>
+						<PiggyBank /> {t('Top up')}
+					</Link>
+				</Button>
+			</div>
+
 			<div className="grid gap-6 md:grid-cols-2">
 				<Card>
 					<CardHeader>
 						<CardTitle>{t('Balances')}</CardTitle>
 					</CardHeader>
 					<CardContent className="space-y-1">
-						{netBalances.map((b) => {
+						{balances.map((b) => {
 							const settled = Math.abs(b.balance) < SETTLED_EPS;
 							const positive = b.balance > 0;
 							return (
@@ -71,13 +90,16 @@ export function GroupSettlement() {
 									className="border-border/60 flex items-center gap-3 border-b border-dashed py-2 last:border-0"
 								>
 									<Avatar name={b.name} className="size-8 text-xs" />
-									<span className="flex-1 truncate text-sm font-medium">
-										{b.name}
-										{b.memberId === bankerId && (
-											<Badge variant="muted" className="ml-2 align-middle">
-												{t('Banker')}
-											</Badge>
-										)}
+									<span className="min-w-0 flex-1">
+										<span className="flex items-center gap-2 text-sm font-medium">
+											<span className="truncate">{b.name}</span>
+											{b.memberId === holderId && <Badge variant="muted">{t('Holder')}</Badge>}
+										</span>
+										{deposited[b.memberId] ? (
+											<span className="text-muted-foreground tnum block text-xs">
+												{t('Deposited')} ${deposited[b.memberId]}
+											</span>
+										) : null}
 									</span>
 									<span
 										className={cn(
@@ -136,14 +158,45 @@ export function GroupSettlement() {
 				</Card>
 			</div>
 
-			{recorded.length > 0 && (
+			{recordedTopups.length > 0 && (
+				<Card>
+					<CardHeader>
+						<CardTitle>{t('Top-ups')}</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<ul className="space-y-2">
+							{recordedTopups.map((txn) => {
+								const memberId = Object.keys(txn.paidBy)[0] ?? '';
+								return (
+									<li key={txn.id} className="border-border/60 flex items-center gap-2 rounded-lg border px-3 py-2">
+										<PiggyBank className="text-primary size-4 shrink-0" />
+										<span className="truncate text-sm font-medium">{nameOf(memberId)}</span>
+										<span className="tnum ml-auto font-semibold">${txn.total}</span>
+										<Button
+											type="button"
+											size="sm"
+											variant="ghost"
+											className="text-muted-foreground hover:text-destructive shrink-0"
+											onClick={() => removeTransaction(txn)}
+										>
+											<Undo2 /> {t('Undo')}
+										</Button>
+									</li>
+								);
+							})}
+						</ul>
+					</CardContent>
+				</Card>
+			)}
+
+			{recordedTransfers.length > 0 && (
 				<Card>
 					<CardHeader>
 						<CardTitle>{t('Recorded payments')}</CardTitle>
 					</CardHeader>
 					<CardContent>
 						<ul className="space-y-2">
-							{recorded.map((txn) => {
+							{recordedTransfers.map((txn) => {
 								const fromId = Object.keys(txn.paidBy)[0] ?? '';
 								const toId = Object.keys(txn.paidFor)[0] ?? '';
 								return (
@@ -152,15 +205,12 @@ export function GroupSettlement() {
 										<ArrowRight className="text-muted-foreground size-4 shrink-0" />
 										<span className="truncate text-sm font-medium">{nameOf(toId)}</span>
 										<span className="tnum ml-auto font-semibold">${txn.total}</span>
-										<span className="text-muted-foreground hidden text-xs sm:inline">
-											{txn.createdAt ? new Date(txn.createdAt).toLocaleDateString() : ''}
-										</span>
 										<Button
 											type="button"
 											size="sm"
 											variant="ghost"
 											className="text-muted-foreground hover:text-destructive shrink-0"
-											onClick={() => undoTransfer(txn)}
+											onClick={() => removeTransaction(txn)}
 										>
 											<Undo2 /> {t('Undo')}
 										</Button>

--- a/frontend/src/pages/Group/TopUp.tsx
+++ b/frontend/src/pages/Group/TopUp.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import ObjectId from 'bson-objectid';
+import { PiggyBank } from 'lucide-react';
+
+import { useGroupContext } from '../../context/GroupContext';
+import { trackTopupRecorded } from '../../utils/activity-tracker';
+import type { Transaction } from '../../types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function GroupTopUp() {
+	const { t } = useTranslation();
+	const { groupId } = useParams();
+	const navigate = useNavigate();
+	const { data: group, updateGroup } = useGroupContext();
+	const members = group.members ?? [];
+
+	const [memberId, setMemberId] = useState<string>(members[0]?.id ?? '');
+	const [amount, setAmount] = useState<number>(0);
+	const [note, setNote] = useState<string>('');
+	const [error, setError] = useState<string | null>(null);
+
+	if (members.length === 0) {
+		return (
+			<Card className="mx-auto max-w-md text-center">
+				<CardContent className="text-muted-foreground py-10">{t('No transactions found')}</CardContent>
+			</Card>
+		);
+	}
+
+	function handleSubmit(event: FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		if (!memberId || !amount) {
+			setError(t('Please fill in the date, total and description.'));
+			return;
+		}
+		const name = members.find((m) => m.id === memberId)?.name ?? '';
+		const txn: Transaction = {
+			id: String(new ObjectId()),
+			type: 'topup',
+			date: new Date(),
+			createdAt: new Date(),
+			description: note || 'Top up',
+			total: amount,
+			paidBy: { [memberId]: amount },
+			paidFor: {},
+		};
+		const updated = trackTopupRecorded(group, name, amount);
+		updated.transactions = [...(updated.transactions ?? []), txn];
+		updateGroup(updated);
+		navigate(`/group/${groupId}/settlement`);
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="mx-auto max-w-md">
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<PiggyBank className="text-primary size-5" /> {t('Top up')}
+					</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div>
+						<Label htmlFor="topup-member" className="mb-1.5">
+							{t('Member')}
+						</Label>
+						<select
+							id="topup-member"
+							value={memberId}
+							onChange={(e) => setMemberId(e.target.value)}
+							className="border-input bg-background focus-visible:border-ring focus-visible:ring-ring/50 flex h-10 w-full rounded-md border px-3 py-2 text-base shadow-xs outline-none focus-visible:ring-[3px]"
+						>
+							{members.map((m) => (
+								<option key={m.id} value={m.id}>
+									{m.name || t('Name')}
+								</option>
+							))}
+						</select>
+					</div>
+					<div>
+						<Label htmlFor="topup-amount" className="mb-1.5">
+							{t('Amount')}
+						</Label>
+						<div className="relative">
+							<span className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm">
+								$
+							</span>
+							<Input
+								id="topup-amount"
+								className="tnum pl-7"
+								type="number"
+								placeholder="0"
+								value={amount || ''}
+								onChange={(e) => setAmount(Number(e.target.value) || 0)}
+							/>
+						</div>
+					</div>
+					<div>
+						<Label htmlFor="topup-note" className="mb-1.5">
+							{t('Note')}
+						</Label>
+						<Input
+							id="topup-note"
+							type="text"
+							placeholder={t('TypeHere')}
+							value={note}
+							onChange={(e) => setNote(e.target.value)}
+						/>
+					</div>
+					<div className="flex items-center justify-end gap-4">
+						{error && (
+							<p role="alert" className="text-destructive text-sm font-medium">
+								{error}
+							</p>
+						)}
+						<Button type="submit">
+							<PiggyBank /> {t('Top up')}
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+		</form>
+	);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,15 +11,15 @@ export type AmountMap = Record<string, number>;
 export interface Member {
 	id: string;
 	name: string;
-	/** Pre-funded balance, like a pre-paid card. */
-	prepaid: number;
+	/** @deprecated Legacy pre-funded amount; migrated to a `topup` transaction on load. */
+	prepaid?: number;
 }
 
 /**
  * 'expense' = consumption (the full split form). 'transfer' = money moved between
  * members (a settle-up, or prepaid into the pot) — same shape, simpler entry.
  */
-export type TransactionType = 'expense' | 'transfer';
+export type TransactionType = 'expense' | 'transfer' | 'topup';
 
 export interface Transaction {
 	id: string;
@@ -49,7 +49,9 @@ export interface Activity {
 
 export interface GroupConfig {
 	name?: string;
-	/** Member who holds the prepaid pot; used by settlement. Defaults to the first member. */
+	/** Member who holds the pooled top-up cash (a holder, not an owner). Defaults to the first member. */
+	holderId?: string;
+	/** @deprecated Renamed to `holderId`; migrated on load. */
 	bankerId?: string;
 }
 

--- a/frontend/src/utils/activity-tracker.ts
+++ b/frontend/src/utils/activity-tracker.ts
@@ -20,6 +20,10 @@ export const ACTIVITY_TYPES = {
 	// Settle-up transfer activities
 	TRANSFER_RECORDED: 'transfer_recorded',
 	TRANSFER_REMOVED: 'transfer_removed',
+
+	// Top-up activities
+	TOPUP_RECORDED: 'topup_recorded',
+	TOPUP_REMOVED: 'topup_removed',
 } as const;
 
 export type ActivityType = (typeof ACTIVITY_TYPES)[keyof typeof ACTIVITY_TYPES];
@@ -107,26 +111,6 @@ export function trackMemberNameChange(group: Group, memberId: string, oldName: s
 	const activity = createActivity(ACTIVITY_TYPES.MEMBER_UPDATED, {
 		description: `Member name changed from "${oldName}" to "${newName}"`,
 		details: { memberId, oldName, newName, changeType: 'name' },
-	});
-
-	return addActivityToGroup(group, activity);
-}
-
-/**
- * Track member prepaid amount change
- */
-export function trackMemberPrepaidChange(
-	group: Group,
-	memberId: string,
-	memberName: string,
-	oldAmount: number,
-	newAmount: number,
-): Group {
-	if (oldAmount === newAmount) return group;
-
-	const activity = createActivity(ACTIVITY_TYPES.MEMBER_UPDATED, {
-		description: `${memberName}'s prepaid amount changed from $${oldAmount} to $${newAmount}`,
-		details: { memberId, memberName, oldAmount, newAmount, changeType: 'prepaid' },
 	});
 
 	return addActivityToGroup(group, activity);
@@ -236,13 +220,6 @@ export function trackMemberChanges(group: Group, oldMembers: Member[] = [], newM
 		} else {
 			// Check for changes in existing member
 			updatedGroup = trackMemberNameChange(updatedGroup, newMember.id, oldMember.name, newMember.name);
-			updatedGroup = trackMemberPrepaidChange(
-				updatedGroup,
-				newMember.id,
-				newMember.name,
-				oldMember.prepaid,
-				newMember.prepaid,
-			);
 		}
 	}
 
@@ -267,6 +244,28 @@ export function trackTransferRemoved(group: Group, fromName: string, toName: str
 	const activity = createActivity(ACTIVITY_TYPES.TRANSFER_REMOVED, {
 		description: `Removed payment: ${fromName} → ${toName} $${amount}`,
 		details: { fromName, toName, amount },
+	});
+	return addActivityToGroup(group, activity);
+}
+
+/**
+ * Track a recorded top-up (a member adding money to the pot).
+ */
+export function trackTopupRecorded(group: Group, memberName: string, amount: number): Group {
+	const activity = createActivity(ACTIVITY_TYPES.TOPUP_RECORDED, {
+		description: `${memberName} topped up $${amount}`,
+		details: { memberName, amount },
+	});
+	return addActivityToGroup(group, activity);
+}
+
+/**
+ * Track the removal (undo) of a top-up.
+ */
+export function trackTopupRemoved(group: Group, memberName: string, amount: number): Group {
+	const activity = createActivity(ACTIVITY_TYPES.TOPUP_REMOVED, {
+		description: `Removed top-up: ${memberName} $${amount}`,
+		details: { memberName, amount },
 	});
 	return addActivityToGroup(group, activity);
 }

--- a/frontend/src/utils/settlement.test.ts
+++ b/frontend/src/utils/settlement.test.ts
@@ -1,229 +1,137 @@
 import { describe, it, expect } from 'vitest';
 
 import type { Group, Transaction } from '../types';
-import { computeBalances, computeSettlement, type Transfer } from './settlement';
+import { computeBalances, computeSettlement, topupTotal, type Transfer } from './settlement';
 
-function netTransfer(transfers: Transfer[], memberId: string): number {
-	let net = 0;
-	for (const t of transfers) {
-		if (t.toId === memberId) net += t.amount;
-		if (t.fromId === memberId) net -= t.amount;
-	}
-	return Math.round(net * 100) / 100;
-}
+const member = (id: string) => ({ id, name: id.toUpperCase() });
 
-function balanceOf(group: Group, memberId: string): number {
-	return computeBalances(group).find((b) => b.memberId === memberId)!.balance;
-}
+const topup = (id: string, m: string, amount: number): Transaction => ({
+	id,
+	type: 'topup',
+	date: '2026-01-01',
+	description: 'Top up',
+	total: amount,
+	paidBy: { [m]: amount },
+	paidFor: {},
+});
 
-// The worked example from the design spec.
-const beachTrip: Group = {
-	config: { name: 'Beach Trip', bankerId: 'alice' },
-	members: [
-		{ id: 'alice', name: 'Alice', prepaid: 100 },
-		{ id: 'bob', name: 'Bob', prepaid: 0 },
-		{ id: 'carol', name: 'Carol', prepaid: 50 },
-	],
-	transactions: [
-		{
-			id: 't1',
-			date: '2026-06-14',
-			description: 'Dinner',
-			total: 120,
-			paidBy: { carol: 120 },
-			paidFor: { alice: 40, bob: 40, carol: 40 },
-		},
-	],
-};
+const expense = (id: string, paidBy: Record<string, number>, paidFor: Record<string, number>): Transaction => ({
+	id,
+	date: '2026-01-01',
+	description: 'x',
+	total: Object.values(paidBy).reduce((s, v) => s + v, 0),
+	paidBy,
+	paidFor,
+});
+
+const transfer = (id: string, from: string, to: string, amount: number): Transaction => ({
+	id,
+	type: 'transfer',
+	date: '2026-01-01',
+	description: 'Settle up',
+	total: amount,
+	paidBy: { [from]: amount },
+	paidFor: { [to]: amount },
+});
+
+const netTransfer = (transfers: Transfer[], id: string) =>
+	Math.round(
+		transfers.reduce((net, t) => net + (t.toId === id ? t.amount : 0) - (t.fromId === id ? t.amount : 0), 0) * 100,
+	) / 100;
 
 describe('computeBalances', () => {
-	it('computes prepaid + paidBy - paidFor per member', () => {
-		const balances = computeBalances(beachTrip);
-		const byId = Object.fromEntries(balances.map((b) => [b.memberId, b.balance]));
-		expect(byId).toEqual({ alice: 60, bob: -40, carol: 130 });
+	it('sums paidBy minus paidFor across all transactions (top-up credits its member)', () => {
+		const g: Group = {
+			config: {},
+			members: [member('a'), member('b')],
+			transactions: [expense('e1', { a: 100 }, { a: 50, b: 50 }), topup('t1', 'a', 30)],
+		};
+		const byId = Object.fromEntries(computeBalances(g).map((b) => [b.memberId, b.balance]));
+		expect(byId).toEqual({ a: 80, b: -50 });
 	});
+});
 
-	it('includes the member name', () => {
-		const alice = computeBalances(beachTrip).find((b) => b.memberId === 'alice');
-		expect(alice?.name).toBe('Alice');
+describe('topupTotal', () => {
+	it('sums only top-up transactions', () => {
+		const g: Group = {
+			config: {},
+			members: [member('a'), member('b')],
+			transactions: [topup('t1', 'a', 100), topup('t2', 'b', 50), expense('e1', { a: 20 }, { a: 10, b: 10 })],
+		};
+		expect(topupTotal(g)).toBe(150);
 	});
 });
 
 describe('computeSettlement', () => {
-	it('settles every member to their fair share (banker holds the prepaid pot)', () => {
-		const { transfers, bankerId } = computeSettlement(beachTrip);
-		const pot = 150; // sum of prepaid
-		for (const m of beachTrip.members!) {
-			const effective = balanceOf(beachTrip, m.id) - (m.id === bankerId ? pot : 0);
-			// Each member's net cash movement must equal their effective balance.
-			expect(netTransfer(transfers, m.id)).toBeCloseTo(effective, 2);
-		}
+	it('refunds each member their top-up when nothing is spent (holder is the hub)', () => {
+		const g: Group = {
+			config: { holderId: 'a' },
+			members: [member('a'), member('b'), member('c')],
+			transactions: [topup('t1', 'b', 100), topup('t2', 'c', 50)],
+		};
+		expect(computeSettlement(g).transfers).toEqual([
+			{ fromId: 'a', fromName: 'A', toId: 'b', toName: 'B', amount: 100 },
+			{ fromId: 'a', fromName: 'A', toId: 'c', toName: 'C', amount: 50 },
+		]);
 	});
 
-	it('exposes net balances (post-banker) that sum to zero and match the transfers', () => {
-		const { netBalances, transfers } = computeSettlement(beachTrip);
-		const sum = netBalances.reduce((acc, b) => acc + b.balance, 0);
-		expect(Math.abs(sum)).toBeLessThan(0.005);
-		for (const nb of netBalances) {
-			expect(netTransfer(transfers, nb.memberId)).toBeCloseTo(nb.balance, 2);
-		}
-	});
-
-	it('produces at most n-1 transfers with positive amounts', () => {
-		const { transfers } = computeSettlement(beachTrip);
-		expect(transfers.length).toBeLessThanOrEqual(beachTrip.members!.length - 1);
-		expect(transfers.every((t) => t.amount > 0)).toBe(true);
-	});
-
-	it('returns no transfers when everyone is already even', () => {
-		const even: Group = {
-			config: { bankerId: 'a' },
-			members: [
-				{ id: 'a', name: 'A', prepaid: 0 },
-				{ id: 'b', name: 'B', prepaid: 0 },
-			],
+	it('holder refunds unused top-ups and out-of-pocket spend after expenses', () => {
+		const g: Group = {
+			config: { holderId: 'a' },
+			members: [member('a'), member('b'), member('c')],
 			transactions: [
-				{
-					id: 't1',
-					date: '2026-01-01',
-					description: 'x',
-					total: 100,
-					paidBy: { a: 50, b: 50 },
-					paidFor: { a: 50, b: 50 },
-				},
+				topup('t1', 'a', 100),
+				topup('t2', 'b', 100),
+				topup('t3', 'c', 100),
+				expense('e1', { b: 90 }, { a: 30, b: 30, c: 30 }), // B paid the street food out of pocket
 			],
 		};
-		expect(computeSettlement(even).transfers).toEqual([]);
+		const { transfers } = computeSettlement(g);
+		// A holds the 300 pot: effective A −230, B +160, C +70.
+		expect(netTransfer(transfers, 'a')).toBeCloseTo(-230, 2);
+		expect(netTransfer(transfers, 'b')).toBeCloseTo(160, 2);
+		expect(netTransfer(transfers, 'c')).toBeCloseTo(70, 2);
+		expect(transfers.every((t) => t.fromId === 'a')).toBe(true); // holder is the hub
 	});
 
-	it('handles a single payer and single ower', () => {
+	it('falls back to plain fewest-transfers when there are no top-ups', () => {
 		const g: Group = {
-			config: { bankerId: 'a' },
-			members: [
-				{ id: 'a', name: 'A', prepaid: 0 },
-				{ id: 'b', name: 'B', prepaid: 0 },
-			],
-			transactions: [
-				{
-					id: 't1',
-					date: '2026-01-01',
-					description: 'x',
-					total: 100,
-					paidBy: { a: 100 },
-					paidFor: { a: 50, b: 50 },
-				},
-			],
+			config: {},
+			members: [member('a'), member('b')],
+			transactions: [expense('e1', { a: 100 }, { a: 50, b: 50 })],
 		};
 		expect(computeSettlement(g).transfers).toEqual([
 			{ fromId: 'b', fromName: 'B', toId: 'a', toName: 'A', amount: 50 },
 		]);
 	});
 
-	it('keeps cents balanced with non-even splits (no phantom transfers)', () => {
-		const g: Group = {
-			config: { bankerId: 'a' },
-			members: [
-				{ id: 'a', name: 'A', prepaid: 0 },
-				{ id: 'b', name: 'B', prepaid: 0 },
-				{ id: 'c', name: 'C', prepaid: 0 },
-			],
-			transactions: [
-				{
-					id: 't1',
-					date: '2026-01-01',
-					description: 'x',
-					total: 100,
-					paidBy: { a: 100 },
-					paidFor: { a: 33.33, b: 33.33, c: 33.34 },
-				},
-			],
+	it('settles everyone once the suggested refund transfers are recorded', () => {
+		const base: Group = {
+			config: { holderId: 'a' },
+			members: [member('a'), member('b'), member('c')],
+			transactions: [topup('t1', 'b', 100), topup('t2', 'c', 50)],
 		};
-		const { transfers } = computeSettlement(g);
-		expect(transfers.every((t) => t.amount > 0)).toBe(true);
-		// Every member ends within a cent of their effective balance.
-		for (const m of g.members!) {
-			const effective = balanceOf(g, m.id) - (m.id === 'a' ? 0 : 0);
-			expect(netTransfer(transfers, m.id)).toBeCloseTo(effective, 2);
-		}
+		const withRefunds: Group = {
+			...base,
+			transactions: [...base.transactions!, transfer('r1', 'a', 'b', 100), transfer('r2', 'a', 'c', 50)],
+		};
+		expect(computeSettlement(withRefunds).transfers).toEqual([]);
 	});
 
-	it('defaults the banker to the first member when bankerId is unset', () => {
-		const g: Group = {
-			config: {},
-			members: [
-				{ id: 'a', name: 'A', prepaid: 0 },
-				{ id: 'b', name: 'B', prepaid: 0 },
-			],
-			transactions: [],
-		};
-		expect(computeSettlement(g).bankerId).toBe('a');
+	it('defaults the holder to the first member when holderId is unset', () => {
+		const g: Group = { config: {}, members: [member('a'), member('b')], transactions: [topup('t1', 'b', 10)] };
+		expect(computeSettlement(g).holderId).toBe('a');
 	});
 
-	it('does not throw and returns no transfers for an empty group', () => {
-		const empty: Group = { config: {} };
-		const result = computeSettlement(empty);
-		expect(result.transfers).toEqual([]);
-		expect(result.balances).toEqual([]);
+	it('returns no transfers and no holder for an empty group', () => {
+		const result = computeSettlement({ config: {} });
+		expect(result).toEqual({ balances: [], transfers: [], holderId: null });
 	});
 
 	it('produces at most n-1 transfers for a 10-member group', () => {
-		const members = Array.from({ length: 10 }, (_, i) => ({ id: `m${i}`, name: `M${i}`, prepaid: 0 }));
-		const paidFor = Object.fromEntries(members.map((m) => [m.id, 10]));
-		const g: Group = {
-			config: { bankerId: 'm0' },
-			members,
-			transactions: [{ id: 't1', date: '2026-01-01', description: 'x', total: 100, paidBy: { m0: 100 }, paidFor }],
-		};
-		const { transfers } = computeSettlement(g);
-		expect(transfers.length).toBeLessThanOrEqual(9);
-	});
-});
-
-describe('settle-up transfers (stored as transactions)', () => {
-	// A transfer: sender on paidBy (credit), recipient on paidFor (debit).
-	const transfer = (id: string, from: string, to: string, amount: number): Transaction => ({
-		id,
-		type: 'transfer',
-		date: '2026-06-15',
-		description: 'Settle up',
-		total: amount,
-		paidBy: { [from]: amount },
-		paidFor: { [to]: amount },
-	});
-
-	const singlePayer: Group = {
-		config: { bankerId: 'a' },
-		members: [
-			{ id: 'a', name: 'A', prepaid: 0 },
-			{ id: 'b', name: 'B', prepaid: 0 },
-		],
-		transactions: [
-			{ id: 't1', date: '2026-01-01', description: 'x', total: 100, paidBy: { a: 100 }, paidFor: { a: 50, b: 50 } },
-		],
-	};
-
-	it('folds a transfer into balances: payer up, payee down', () => {
-		const g: Group = { ...singlePayer, transactions: [...singlePayer.transactions!, transfer('p1', 'b', 'a', 50)] };
-		const byId = Object.fromEntries(computeBalances(g).map((b) => [b.memberId, b.balance]));
-		expect(byId).toEqual({ a: 0, b: 0 });
-	});
-
-	it('settles everyone once the suggested transfers are recorded as transfers', () => {
-		const withTransfers: Group = {
-			...beachTrip,
-			transactions: [
-				...beachTrip.transactions!,
-				transfer('p1', 'bob', 'carol', 40),
-				transfer('p2', 'alice', 'carol', 90),
-			],
-		};
-		expect(computeSettlement(withTransfers).transfers).toEqual([]);
-	});
-
-	it('a partial transfer reduces but does not clear the debt', () => {
-		const g: Group = { ...singlePayer, transactions: [...singlePayer.transactions!, transfer('p1', 'b', 'a', 20)] };
-		expect(computeSettlement(g).transfers).toEqual([
-			{ fromId: 'b', fromName: 'B', toId: 'a', toName: 'A', amount: 30 },
-		]);
+		const members = Array.from({ length: 10 }, (_, i) => member(`m${i}`));
+		const transactions = members.slice(1).map((m, i) => topup(`t${i}`, m.id, 10));
+		const g: Group = { config: { holderId: 'm0' }, members, transactions };
+		expect(computeSettlement(g).transfers.length).toBeLessThanOrEqual(9);
 	});
 });

--- a/frontend/src/utils/settlement.ts
+++ b/frontend/src/utils/settlement.ts
@@ -3,7 +3,7 @@ import type { Group } from '../types';
 export interface MemberBalance {
 	memberId: string;
 	name: string;
-	/** prepaid + paidBy − paidFor. Positive = owed money, negative = owes. */
+	/** Σ paidBy − Σ paidFor across all transactions. Positive = owed money, negative = owes. */
 	balance: number;
 }
 
@@ -16,12 +16,10 @@ export interface Transfer {
 }
 
 export interface SettlementResult {
-	/** Raw position per member: prepaid + paidBy − paidFor. */
 	balances: MemberBalance[];
-	/** Net position after the banker absorbs the prepaid pot; sums to ~0 and matches `transfers`. */
-	netBalances: MemberBalance[];
 	transfers: Transfer[];
-	bankerId: string | null;
+	/** The top-holder (holds the pooled top-up cash); settlement refunds route through them. */
+	holderId: string | null;
 }
 
 /** Amounts below this (half a cent) are treated as settled. */
@@ -32,16 +30,14 @@ function round(value: number): number {
 }
 
 /**
- * Per-member balance: prepaid + everything they paid (paidBy) − everything they
- * should be charged (paidFor), summed across all transactions.
+ * Per-member balance: everything they put in (paidBy, incl. top-ups) minus their
+ * share of expenses (paidFor), across every transaction. A top-up is a transaction
+ * that only credits its member; a settle-up transfer credits sender / debits recipient.
  */
 export function computeBalances(group: Group): MemberBalance[] {
 	const members = group.members ?? [];
 	const transactions = group.transactions ?? [];
 
-	// Both expenses and transfers are transactions: paidBy is money in (credit),
-	// paidFor is money out (debit). A settle-up transfer therefore folds in for free
-	// (the payer is paidBy, the recipient is paidFor).
 	return members.map((member) => {
 		let paidBy = 0;
 		let paidFor = 0;
@@ -49,12 +45,13 @@ export function computeBalances(group: Group): MemberBalance[] {
 			paidBy += tx.paidBy?.[member.id] ?? 0;
 			paidFor += tx.paidFor?.[member.id] ?? 0;
 		}
-		return {
-			memberId: member.id,
-			name: member.name,
-			balance: round((member.prepaid ?? 0) + paidBy - paidFor),
-		};
+		return { memberId: member.id, name: member.name, balance: round(paidBy - paidFor) };
 	});
+}
+
+/** Total money currently held in the pot (sum of all top-up transactions). */
+export function topupTotal(group: Group): number {
+	return round((group.transactions ?? []).filter((tx) => tx.type === 'topup').reduce((sum, tx) => sum + tx.total, 0));
 }
 
 interface EffectiveEntry {
@@ -85,13 +82,7 @@ function minimizeTransfers(entries: EffectiveEntry[]): Transfer[] {
 		const creditor = creditors[j];
 		const amount = round(Math.min(debtor.amount, creditor.amount));
 		if (amount > EPS) {
-			transfers.push({
-				fromId: debtor.id,
-				fromName: debtor.name,
-				toId: creditor.id,
-				toName: creditor.name,
-				amount,
-			});
+			transfers.push({ fromId: debtor.id, fromName: debtor.name, toId: creditor.id, toName: creditor.name, amount });
 		}
 		debtor.amount = round(debtor.amount - amount);
 		creditor.amount = round(creditor.amount - amount);
@@ -102,35 +93,31 @@ function minimizeTransfers(entries: EffectiveEntry[]): Transfer[] {
 }
 
 /**
- * Compute balances and the fewest transfers to settle the group. The banker
- * holds the prepaid pot (Σ prepaid), so their effective balance is reduced by
- * it — which makes effective balances sum to zero and settle peer-to-peer.
+ * Compute balances and the fewest transfers to settle the group.
+ *
+ * The top-holder physically holds the pooled top-up cash, so for the transfer
+ * computation their position is offset by −Σtop-ups (they owe the pot back). This
+ * makes effective balances sum to zero and routes refunds through the holder. When
+ * there are no top-ups the offset is zero and it degrades to plain peer-to-peer
+ * fewest-transfers.
  */
 export function computeSettlement(group: Group): SettlementResult {
 	const members = group.members ?? [];
 	const balances = computeBalances(group);
 
 	if (members.length === 0) {
-		return { balances, netBalances: [], transfers: [], bankerId: null };
+		return { balances, transfers: [], holderId: null };
 	}
 
-	const configuredBanker = group.config?.bankerId;
-	const bankerId =
-		configuredBanker && members.some((m) => m.id === configuredBanker) ? configuredBanker : members[0].id;
-
-	const pot = members.reduce((sum, m) => sum + (m.prepaid ?? 0), 0);
+	const configured = group.config?.holderId;
+	const holderId = configured && members.some((m) => m.id === configured) ? configured : members[0].id;
+	const pot = topupTotal(group);
 
 	const effective: EffectiveEntry[] = balances.map((b) => ({
 		id: b.memberId,
 		name: b.name,
-		amount: round(b.balance - (b.memberId === bankerId ? pot : 0)),
+		amount: round(b.balance - (b.memberId === holderId ? pot : 0)),
 	}));
 
-	const netBalances: MemberBalance[] = effective.map((e) => ({
-		memberId: e.id,
-		name: e.name,
-		balance: e.amount,
-	}));
-
-	return { balances, netBalances, transfers: minimizeTransfers(effective), bankerId };
+	return { balances, transfers: minimizeTransfers(effective), holderId };
 }

--- a/frontend/src/utils/use-api.ts
+++ b/frontend/src/utils/use-api.ts
@@ -40,6 +40,36 @@ async function updateGroupName(newName: string | undefined, groupId: string): Pr
 function groupStandardize(group?: Group | null): Group {
 	const standardized: Group = group ?? ({} as Group);
 	standardized.config ||= {}; // Initialize config if not present
+
+	// Legacy migration: "banker" → "holder".
+	if (standardized.config.bankerId && !standardized.config.holderId) {
+		standardized.config.holderId = standardized.config.bankerId;
+	}
+	delete standardized.config.bankerId;
+
+	// Legacy migration: a member's prepaid number → a top-up transaction (held by
+	// the holder). Deterministic id keeps it idempotent across reloads.
+	const members = standardized.members ?? [];
+	const legacy = members.filter((m) => (m.prepaid ?? 0) > 0);
+	if (legacy.length) {
+		standardized.transactions ||= [];
+		for (const m of legacy) {
+			const id = `topup-legacy-${m.id}`;
+			if (!standardized.transactions.some((tx) => tx.id === id)) {
+				standardized.transactions.unshift({
+					id,
+					type: 'topup',
+					date: new Date(),
+					description: 'Prepaid',
+					total: m.prepaid as number,
+					paidBy: { [m.id]: m.prepaid as number },
+					paidFor: {},
+				});
+			}
+			delete m.prepaid;
+		}
+	}
+
 	return standardized;
 }
 


### PR DESCRIPTION
## Summary

Generalises "prepaid" into an optional **top-up** and replaces the "banker" with a **top-holder**.

- **Top-up** — a member adds money to the pot any time (a `type: 'topup'` transaction crediting only that member). Optional: a group can pay as-you-go and settle at the end with no top-ups.
- **Top-holder** (`config.holderId`, normally the organizer) *holds* the pooled cash with **no balance effect from holding**. For the transfer computation their position is offset by `−Σtop-ups`, so refunds route through them; with no top-ups it degrades to plain fewest-transfers.
- `balance = ΣpaidBy − ΣpaidFor` (dropped `member.prepaid` and the banker offset/`netBalances`).

## UI

- **Config:** Prepaid input + Banker dropdown → a **Top-holder** dropdown.
- **Top up** entry screen (`/group/:id/topup`) + `TOPUP_RECORDED/REMOVED` Activity.
- **Settle up:** raw balances + "deposited" + **Holder** badge + **Top up** button + a **Top-ups** list with undo. Mark-paid / recorded payments unchanged.

## Migration

Legacy data migrates on load: `member.prepaid` → top-up transactions (held by the holder); `config.bankerId` → `holderId`.

## Testing

- Unit (TDD): top-up credits its member; holder-hub refunds; out-of-pocket payer refunded by holder; no-top-up fallback; holder default; ≤ n−1 transfers (14 tests).
- Live Chrome MCP QA: legacy Beach Trip migrated cleanly (prepaid→top-ups, banker→holder), added a top-up, holder refunds verified.

---

Design spec: `docs/superpowers/specs/2026-06-14-top-up-and-holder-design.md`
